### PR TITLE
Kadai6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 kadai = kadai6
-source = pl1b
-target = pl1b.p
+source = pl1d
+target = pl1d.p
 
 build: parser
 	./parser samples/pascal/$(target)
@@ -34,6 +34,12 @@ test: parser
 	./parser samples/pascal/pl0d.p
 	lli result.ll
 	./parser samples/pascal/pl1a.p
+	lli result.ll
+	./parser samples/pascal/pl1b.p
+	lli result.ll
+	./parser samples/pascal/pl1c.p
+	lli result.ll
+	./parser samples/pascal/pl1d.p
 	lli result.ll
 
 llvm: parser

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 kadai = kadai6
-source = pl1a
-target = pl1a.p
+source = pl1b
+target = pl1b.p
 
 build: parser
 	./parser samples/pascal/$(target)

--- a/data-structures.c
+++ b/data-structures.c
@@ -34,6 +34,38 @@ void factor_push(Factor x) {
   return;
 }
 
+void debug_fstack() {
+  unsigned int top = fstack.top;
+  printf("\nfstack debug: top is %d\n", top);
+  printf("|-----------------------|\n");
+  printf("| type\t| name\t| val\t|\n");
+  printf("|-----------------------|\n");
+
+  while (top > 0) {
+    Factor x = fstack.element[top];
+    printf("| %d\t| %s\t| %d\t|\n", x.type, x.name, x.val);
+    top--;
+  }
+
+  printf("|-----------------------|\n");
+}
+
+void debug_aritystack() {
+  unsigned int top = aritystack.top;
+  printf("\naritystack debug: top is %d\n", top);
+  printf("|-----------------------|\n");
+  printf("| type\t| name\t| val\t|\n");
+  printf("|-----------------------|\n");
+
+  while (top > 0) {
+    Factor x = aritystack.element[top];
+    printf("| %d\t| %s\t| %d\t|\n", x.type, x.name, x.val);
+    top--;
+  }
+
+  printf("|-----------------------|\n");
+}
+
 int label_pop() {
   int label = labelstack.label[labelstack.top];
   labelstack.top--;
@@ -71,6 +103,8 @@ void arity_push(Factor x) {
   return;
 }
 
+int get_aritystack_top() { return aritystack.top; }
+
 void insert_code(LLVMcommand command) {
   LLVMcode *new_code_ptr = generate_code(command);
 
@@ -102,8 +136,10 @@ LLVMcode *generate_code(LLVMcommand command) {
   switch (command) {
     case Alloca:
       retval.type = LOCAL_VAR;
+      strcpy(retval.name, "allo");
       retval.val = reg_counter++;
       (code_ptr->args).alloca.retval = retval;
+      factor_push(retval);
       break;
     case Store:
       arg2 = factor_pop();
@@ -117,6 +153,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       retval.type = LOCAL_VAR;
       retval.val = reg_counter++;
       (code_ptr->args).load.retval = retval;
+      factor_push(retval);
       break;
     case BrUncond:
       //(code_ptr->args).bruncond.arg1 = reg_counter;
@@ -141,6 +178,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       (code_ptr->args).add.arg1 = arg1;
       (code_ptr->args).add.arg2 = arg2;
       (code_ptr->args).add.retval = retval;
+      factor_push(retval);
       break;
     case Sub:
       arg2 = factor_pop();
@@ -150,6 +188,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       (code_ptr->args).sub.arg1 = arg1;
       (code_ptr->args).sub.arg2 = arg2;
       (code_ptr->args).sub.retval = retval;
+      factor_push(retval);
       break;
     case Mult:
       arg2 = factor_pop();
@@ -159,6 +198,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       (code_ptr->args).mult.arg1 = arg1;
       (code_ptr->args).mult.arg2 = arg2;
       (code_ptr->args).mult.retval = retval;
+      factor_push(retval);
       break;
     case Div:
       arg2 = factor_pop();
@@ -168,6 +208,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       (code_ptr->args).div.arg1 = arg1;
       (code_ptr->args).div.arg2 = arg2;
       (code_ptr->args).div.retval = retval;
+      factor_push(retval);
       break;
     case Icmp:
       arg2 = factor_pop();
@@ -178,10 +219,12 @@ LLVMcode *generate_code(LLVMcommand command) {
       (code_ptr->args).icmp.arg2 = arg2;
       (code_ptr->args).icmp.retval = retval;
       (code_ptr->args).icmp.type = cmp_type;
+      factor_push(retval);
       break;
     case Ret:
       arg1 = factor_pop();
       (code_ptr->args).ret.arg1 = arg1;
+      factor_push(retval);
       break;
     case Proc:
       arg1 = factor_pop();
@@ -193,7 +236,6 @@ LLVMcode *generate_code(LLVMcommand command) {
         (code_ptr->args).proc.top++;
         (code_ptr->args).proc.element[(code_ptr->args).proc.top] = x;
       }
-
       break;
     case Read:
       arg1 = factor_pop();
@@ -201,6 +243,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       retval.type = LOCAL_VAR;
       retval.val = reg_counter++;
       (code_ptr->args).read.retval = retval;
+      factor_push(retval);
       break;
     case Write:
       arg1 = factor_pop();
@@ -208,11 +251,9 @@ LLVMcode *generate_code(LLVMcommand command) {
       retval.type = LOCAL_VAR;
       retval.val = reg_counter++;
       (code_ptr->args).write.retval = retval;
-      break;
-    default:
+      factor_push(retval);
       break;
   }
-  factor_push(retval);
 
   return code_ptr;
 }

--- a/kadai/kadai6/Makefile
+++ b/kadai/kadai6/Makefile
@@ -1,7 +1,7 @@
 
 kadai = kadai6
-source = pl1a
-target = pl1a.p
+source = pl1d
+target = pl1d.p
 
 build: parser
 	./parser samples/pascal/$(target)
@@ -34,6 +34,12 @@ test: parser
 	./parser samples/pascal/pl0d.p
 	lli result.ll
 	./parser samples/pascal/pl1a.p
+	lli result.ll
+	./parser samples/pascal/pl1b.p
+	lli result.ll
+	./parser samples/pascal/pl1c.p
+	lli result.ll
+	./parser samples/pascal/pl1d.p
 	lli result.ll
 
 llvm: parser

--- a/kadai/kadai6/data-structures.c
+++ b/kadai/kadai6/data-structures.c
@@ -34,6 +34,38 @@ void factor_push(Factor x) {
   return;
 }
 
+void debug_fstack() {
+  unsigned int top = fstack.top;
+  printf("\nfstack debug: top is %d\n", top);
+  printf("|-----------------------|\n");
+  printf("| type\t| name\t| val\t|\n");
+  printf("|-----------------------|\n");
+
+  while (top > 0) {
+    Factor x = fstack.element[top];
+    printf("| %d\t| %s\t| %d\t|\n", x.type, x.name, x.val);
+    top--;
+  }
+
+  printf("|-----------------------|\n");
+}
+
+void debug_aritystack() {
+  unsigned int top = aritystack.top;
+  printf("\naritystack debug: top is %d\n", top);
+  printf("|-----------------------|\n");
+  printf("| type\t| name\t| val\t|\n");
+  printf("|-----------------------|\n");
+
+  while (top > 0) {
+    Factor x = aritystack.element[top];
+    printf("| %d\t| %s\t| %d\t|\n", x.type, x.name, x.val);
+    top--;
+  }
+
+  printf("|-----------------------|\n");
+}
+
 int label_pop() {
   int label = labelstack.label[labelstack.top];
   labelstack.top--;
@@ -71,6 +103,8 @@ void arity_push(Factor x) {
   return;
 }
 
+int get_aritystack_top() { return aritystack.top; }
+
 void insert_code(LLVMcommand command) {
   LLVMcode *new_code_ptr = generate_code(command);
 
@@ -102,8 +136,10 @@ LLVMcode *generate_code(LLVMcommand command) {
   switch (command) {
     case Alloca:
       retval.type = LOCAL_VAR;
+      strcpy(retval.name, "allo");
       retval.val = reg_counter++;
       (code_ptr->args).alloca.retval = retval;
+      factor_push(retval);
       break;
     case Store:
       arg2 = factor_pop();
@@ -117,6 +153,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       retval.type = LOCAL_VAR;
       retval.val = reg_counter++;
       (code_ptr->args).load.retval = retval;
+      factor_push(retval);
       break;
     case BrUncond:
       //(code_ptr->args).bruncond.arg1 = reg_counter;
@@ -141,6 +178,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       (code_ptr->args).add.arg1 = arg1;
       (code_ptr->args).add.arg2 = arg2;
       (code_ptr->args).add.retval = retval;
+      factor_push(retval);
       break;
     case Sub:
       arg2 = factor_pop();
@@ -150,6 +188,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       (code_ptr->args).sub.arg1 = arg1;
       (code_ptr->args).sub.arg2 = arg2;
       (code_ptr->args).sub.retval = retval;
+      factor_push(retval);
       break;
     case Mult:
       arg2 = factor_pop();
@@ -159,6 +198,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       (code_ptr->args).mult.arg1 = arg1;
       (code_ptr->args).mult.arg2 = arg2;
       (code_ptr->args).mult.retval = retval;
+      factor_push(retval);
       break;
     case Div:
       arg2 = factor_pop();
@@ -168,6 +208,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       (code_ptr->args).div.arg1 = arg1;
       (code_ptr->args).div.arg2 = arg2;
       (code_ptr->args).div.retval = retval;
+      factor_push(retval);
       break;
     case Icmp:
       arg2 = factor_pop();
@@ -178,10 +219,12 @@ LLVMcode *generate_code(LLVMcommand command) {
       (code_ptr->args).icmp.arg2 = arg2;
       (code_ptr->args).icmp.retval = retval;
       (code_ptr->args).icmp.type = cmp_type;
+      factor_push(retval);
       break;
     case Ret:
       arg1 = factor_pop();
       (code_ptr->args).ret.arg1 = arg1;
+      factor_push(retval);
       break;
     case Proc:
       arg1 = factor_pop();
@@ -193,7 +236,6 @@ LLVMcode *generate_code(LLVMcommand command) {
         (code_ptr->args).proc.top++;
         (code_ptr->args).proc.element[(code_ptr->args).proc.top] = x;
       }
-
       break;
     case Read:
       arg1 = factor_pop();
@@ -201,6 +243,7 @@ LLVMcode *generate_code(LLVMcommand command) {
       retval.type = LOCAL_VAR;
       retval.val = reg_counter++;
       (code_ptr->args).read.retval = retval;
+      factor_push(retval);
       break;
     case Write:
       arg1 = factor_pop();
@@ -208,11 +251,9 @@ LLVMcode *generate_code(LLVMcommand command) {
       retval.type = LOCAL_VAR;
       retval.val = reg_counter++;
       (code_ptr->args).write.retval = retval;
-      break;
-    default:
+      factor_push(retval);
       break;
   }
-  factor_push(retval);
 
   return code_ptr;
 }

--- a/kadai/kadai6/result.ll
+++ b/kadai/kadai6/result.ll
@@ -5,28 +5,48 @@
 declare dso_local i32 @__isoc99_scanf(i8*, ...) #1
 declare dso_local i32 @printf(i8*, ...) #1
 
-define void @fact(i32) #0 {
-  %2 = alloca i32, align 4
-  store i32 %0, i32* %2, align 4
-  %3 = load i32, i32* %2, align 4
-  %4 = icmp sle i32 %3, 1
-  br i1 %4, label %5, label %6
+define void @fact(i32, i32) #0 {
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  %5 = alloca i32, align 4
+  %6 = alloca i32, align 4
+  store i32 %0, i32* %3, align 4
+  store i32 %1, i32* %4, align 4
+  store i32 0, i32* %5, align 4
+  store i32 2, i32* %6, align 4
+  %7 = load i32, i32* %3, align 4
+  %8 = icmp sle i32 %7, 1
+  br i1 %8, label %9, label %10
 
-5:
+9:
   store i32 1, i32* @temp, align 4
-  br label %12
+  br label %21
 
-6:
-  %7 = load i32, i32* %2, align 4
-  %8 = sub nsw i32 %7, 1
-  call void @fact(i32 %8)
-  %9 = load i32, i32* @temp, align 4
-  %10 = load i32, i32* %2, align 4
-  %11 = mul nsw i32 %9, %10
-  store i32 %11, i32* @temp, align 4
-  br label %12
+10:
+  %11 = load i32, i32* %3, align 4
+  %12 = sub nsw i32 %11, 1
+  %13 = load i32, i32* %4, align 4
+  %14 = load i32, i32* %5, align 4
+  %15 = add nsw i32 %13, %14
+  %16 = load i32, i32* %6, align 4
+  %17 = add nsw i32 %15, %16
+  call void @fact(i32 %12, i32 %17)
+  %18 = load i32, i32* @temp, align 4
+  %19 = load i32, i32* %3, align 4
+  %20 = mul nsw i32 %18, %19
+  store i32 %20, i32* @temp, align 4
+  br label %21
 
-12:
+21:
+  ret void
+}
+
+define void @test() #0 {
+  %1 = alloca i32, align 4
+  store i32 0, i32* %1, align 4
+  %2 = load i32, i32* %1, align 4
+  %3 = add nsw i32 %2, 1
+  store i32 %3, i32* %1, align 4
   ret void
 }
 
@@ -35,7 +55,8 @@ define i32 @main() #0 {
   store i32 0, i32* %1, align 4
   %2 = call i32 (i8*, ...) @__isoc99_scanf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32* @n)
   %3 = load i32, i32* @n, align 4
-  call void @fact(i32 %3)
+  call void @fact(i32 %3, i32 1)
+  call void @test()
   %4 = load i32, i32* @temp, align 4
   %5 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32 %4)
   ret i32 0

--- a/kadai/kadai6/symbol-table.c
+++ b/kadai/kadai6/symbol-table.c
@@ -91,7 +91,7 @@ Symbol *get_symbol_head_ptr() { return symbol_head_ptr; }
 void debug_symbol_table() {
   Symbol *symbol_ptr = (Symbol *)malloc(sizeof(Symbol));
   symbol_ptr = symbol_tail_ptr;
-
+  printf("\nsymbol_table debug\n");
   printf("|-----------------------|\n");
   printf("| type\t| name\t| val\t|\n");
   printf("|-----------------------|\n");
@@ -107,12 +107,13 @@ void debug_symbol_table() {
   return;
 };
 
-void overwrite_symbol_val(int count) {
+void overwrite_symbol_val(int var_num, int arity_num) {
+  int tmp = arity_num * 2 + var_num;
   Symbol *symbol_ptr = (Symbol *)malloc(sizeof(Symbol));
   symbol_ptr = symbol_tail_ptr;
 
-  while (symbol_ptr && count > 0) {
-    symbol_ptr->val = count--;
+  while (symbol_ptr && tmp > arity_num) {
+    if (symbol_ptr->type == LOCAL_VAR) symbol_ptr->val = tmp--;
     symbol_ptr = symbol_ptr->prev;
   }
 

--- a/kadai/kadai6/y.tab.c
+++ b/kadai/kadai6/y.tab.c
@@ -45,9 +45,44 @@ int tmp1,tmp2, tmp3;
 int arity = 0;
 int i = 0;
 int var_mode = FALSE;
+int arity_mode = FALSE;
+
+int var_num = 0;
+int arity_num = 0;
+
+Factor tmp1_element[100];
+int tmp1_top = 0;
+
+Factor tmp2_element[100];
+int tmp2_top = 0;
+
+void debug_tmp1() {
+        printf("\ntmp1 debug\n");
+        printf("|-----------------------|\n");
+        printf("| type\t| name\t| val\t|\n");
+        printf("|-----------------------|\n");
+
+        for (i = 0; i < tmp1_top; i++) {
+        Factor x = tmp1_element[i];
+        printf("| %d\t| %s\t| %d\t|\n", x.type, x.name,x.val);
+        }
+  printf("|-----------------------|\n");
+}
+void debug_tmp2() {
+        printf("\ntmp2 debug\n");
+        printf("|-----------------------|\n");
+        printf("| type\t| name\t| val\t|\n");
+        printf("|-----------------------|\n");
+
+        for (i = 0; i < tmp2_top; i++) {
+        Factor x = tmp2_element[i];
+        printf("| %d\t| %s\t| %d\t|\n", x.type, x.name,x.val);
+        }
+  printf("|-----------------------|\n");
+}
 
 
-#line 34 "parser.y"
+#line 69 "parser.y"
 #ifdef YYSTYPE
 #undef  YYSTYPE_IS_DECLARED
 #define YYSTYPE_IS_DECLARED 1
@@ -59,7 +94,7 @@ typedef union {
     char ident[MAXLENGTH+1];
 } YYSTYPE;
 #endif /* !YYSTYPE_IS_DECLARED */
-#line 62 "y.tab.c"
+#line 97 "y.tab.c"
 
 /* compatibility with bison */
 #ifdef YYPARSE_PARAM
@@ -134,149 +169,151 @@ extern int YYPARSE_DECL();
 static const short yylhs[] = {                           -1,
     0,    7,    3,    4,    4,    8,    8,   11,    9,    5,
     5,   12,   12,   13,   16,   14,   17,   18,   14,    1,
-   15,   19,   19,    6,    6,    6,    6,    6,    6,    6,
-    6,    6,   20,   31,   33,   21,   32,   34,   32,   35,
-   36,   22,   37,   38,   23,   24,   40,   24,    2,   26,
-   27,   28,   25,   30,   30,   30,   30,   30,   30,   29,
-   29,   29,   29,   29,   41,   41,   41,   42,   42,   42,
-   43,   39,   39,   10,   10,
+   19,   15,   20,   20,    6,    6,    6,    6,    6,    6,
+    6,    6,    6,   21,   32,   34,   22,   33,   35,   33,
+   36,   37,   23,   38,   39,   24,   25,   41,   25,    2,
+   27,   28,   29,   26,   31,   31,   31,   31,   31,   31,
+   30,   30,   30,   30,   30,   42,   42,   42,   43,   43,
+   43,   44,   40,   40,   10,   10,
 };
 static const short yylen[] = {                            2,
     5,    0,    4,    0,    2,    3,    1,    0,    3,    0,
     2,    3,    1,    1,    0,    5,    0,    0,    9,    1,
-    2,    3,    1,    1,    1,    1,    1,    1,    1,    1,
-    1,    1,    3,    0,    0,    7,    0,    0,    3,    0,
-    0,    6,    0,    0,   10,    1,    0,    5,    1,    3,
-    4,    4,    0,    3,    3,    3,    3,    3,    3,    1,
-    2,    2,    3,    3,    1,    3,    3,    1,    1,    3,
-    1,    1,    3,    1,    3,
+    0,    3,    3,    1,    1,    1,    1,    1,    1,    1,
+    1,    1,    1,    3,    0,    0,    7,    0,    0,    3,
+    0,    0,    6,    0,    0,   10,    1,    0,    5,    1,
+    3,    4,    4,    0,    3,    3,    3,    3,    3,    3,
+    1,    2,    2,    3,    3,    1,    3,    3,    1,    1,
+    3,    1,    1,    3,    1,    3,
 };
 static const short yydefred[] = {                         0,
     0,    0,    0,    0,    8,    0,    0,    0,    7,    0,
-    1,    0,    2,    0,   13,   14,    0,   74,    0,   20,
+    1,    0,    2,    0,   13,   14,    0,   75,    0,   20,
     0,    0,    0,    6,    0,   15,    0,    0,    0,    0,
-    0,   40,    0,    0,    0,    3,   24,   25,   26,   27,
-   28,   29,   30,   31,   32,   12,   75,    0,    0,   23,
-    0,    0,    0,    0,    0,   69,   71,    0,    0,    0,
-   65,   68,    0,    0,    0,    0,    0,    0,   16,    0,
-   50,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-    0,    0,    0,    0,   34,    0,    0,    0,    0,    0,
-    0,    0,    0,   21,    0,   22,    0,   70,    0,    0,
-    0,    0,    0,    0,    0,    0,    0,   66,   67,   51,
-   41,   52,    0,    0,   18,    0,   35,    0,    0,   48,
-    0,    0,    0,   42,   19,    0,   38,   36,    0,    0,
-    0,   39,   45,
+    0,   41,    0,    0,    0,    3,   25,   26,   27,   28,
+   29,   30,   31,   32,   33,   12,   76,    0,    0,   24,
+    0,    0,    0,    0,    0,   70,   72,    0,    0,    0,
+   66,   69,    0,    0,    0,    0,    0,   21,   16,    0,
+   51,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,   35,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,    0,   23,    0,   71,    0,    0,
+    0,    0,    0,    0,    0,    0,    0,   67,   68,   52,
+   42,   53,    0,    0,   22,   18,    0,   36,    0,    0,
+   49,    0,    0,    0,   43,   19,    0,   39,   37,    0,
+    0,    0,   40,   46,
 };
 static const short yydgoto[] = {                          2,
    21,   35,    6,   68,   13,   36,   22,    8,    9,   19,
-   10,   14,   15,   16,   69,   48,   27,  121,   51,   37,
-   38,   39,   40,   41,   42,   43,   44,   45,   58,   59,
-  107,  128,  123,  130,   64,  118,  116,  129,   93,  114,
-   60,   61,   62,
+   10,   14,   15,   16,   69,   48,   27,  122,   94,   51,
+   37,   38,   39,   40,   41,   42,   43,   44,   45,   58,
+   59,  107,  129,  124,  131,   64,  119,  117,  130,   93,
+  114,   60,   61,   62,
 };
-static const short yysindex[] = {                      -229,
- -272,    0, -240, -199,    0, -233, -187, -206,    0, -196,
-    0, -181,    0, -173,    0,    0, -199,    0, -159,    0,
- -151, -153, -187,    0, -154,    0, -148, -153, -146, -119,
- -114,    0, -113, -121,  -99,    0,    0,    0,    0,    0,
-    0,    0,    0,    0,    0,    0,    0, -199, -196,    0,
- -256, -110, -278, -278, -119,    0,    0,   17,  -83, -155,
-    0,    0, -106, -119, -119, -119, -119, -153,    0, -266,
-    0, -153, -119, -155, -155, -267, -278, -278, -119, -119,
- -119, -119, -119, -119,    0, -278, -278,  -95,  -63, -221,
- -123, -123,  -91,    0,  -90,    0, -123,    0, -155, -155,
- -123, -123, -123, -123, -123, -123, -153,    0,    0,    0,
-    0,    0, -119,  -85,    0,  -69,    0, -153, -123,    0,
- -199, -119,  -56,    0,    0, -123,    0,    0,  -53, -153,
- -153,    0,    0,
+static const short yysindex[] = {                      -256,
+ -270,    0, -240, -209,    0, -219, -189, -199,    0, -198,
+    0, -176,    0, -149,    0,    0, -209,    0, -147,    0,
+ -136, -150, -189,    0, -135,    0, -193, -150, -129, -119,
+ -125,    0, -115, -114, -110,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,    0,    0,    0, -209, -198,    0,
+ -254, -113, -276, -276, -119,    0,    0,   21,  -82, -273,
+    0,    0, -106, -119, -119, -119, -119,    0,    0, -151,
+    0, -150, -119, -273, -273, -154, -276, -276, -119, -119,
+ -119, -119, -119, -119,    0, -276, -276,  -95,  -66, -139,
+ -258, -258,  -94, -150,  -90,    0, -258,    0, -273, -273,
+ -258, -258, -258, -258, -258, -258, -150,    0,    0,    0,
+    0,    0, -119,  -85,    0,    0,  -69,    0, -150, -258,
+    0, -209, -119,  -58,    0,    0, -258,    0,    0,  -56,
+ -150, -150,    0,    0,
 };
 static const short yyrindex[] = {                         0,
-    0,    0,    0, -210,    0,    0, -197,    0,    0,    0,
-    0,    0,    0,    0,    0,    0, -222,    0,  -84,    0,
-  -75,  -82, -184,    0,    0,    0,    0, -252,    0,    0,
-    0,    0,    0, -250, -257,    0,    0,    0,    0,    0,
-    0,    0,    0,    0,    0,    0,    0, -172,    0,    0,
-    0,    0,    0,    0,    0,    0,    0,    0,    0, -135,
-    0,    0,    0,    0,    0,    0,    0,  -72,    0,    0,
-    0, -252,    0, -101,  -67,    0,    0,    0,    0,    0,
+    0,    0,    0, -214,    0,    0, -197,    0,    0,    0,
+    0,    0,    0,    0,    0,    0, -226,    0,  -84,    0,
+  -80,  -83, -179,    0,    0,    0,    0, -246,    0,    0,
+    0,    0,    0, -251, -255,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,    0,    0,    0, -162,    0,    0,
+    0,    0,    0,    0,    0,    0,    0,    0,    0, -131,
     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
- -128, -264,  -66,    0,    0,    0,  -50,    0,  -33,    1,
- -244, -212, -182, -167, -141, -132,  -94,    0,    0,    0,
-    0,    0,    0,    0,    0,    0,    0,  -94, -175,    0,
- -172,    0, -195,    0,    0,  -36,    0,    0,    0,  -94,
-  -94,    0,    0,
+    0, -246,    0,  -97,  -63,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+ -239, -118,  -77,  -79,    0,    0,  -57,    0,  -29,    5,
+ -195, -187, -160, -152, -145, -127, -205,    0,    0,    0,
+    0,    0,    0,    0,    0,    0,    0,    0, -205, -117,
+    0, -162,    0, -204,    0,    0,  -45,    0,    0,    0,
+ -205, -205,    0,    0,
 };
 static const short yygindex[] = {                         0,
-    0,    0,    0,  219,    0,  -28,    0,    0,  211,  180,
-    0,    0,  207,    0,  110,    0,    0,    0,    0,    0,
-    0,    0,    0,    0,    0,    0,    0,    0,  -54,  168,
-    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-   52,   75,    0,
+    0,    0,    0,  216,    0,  -28,    0,    0,  205,  174,
+    0,    0,  203,    0,  105,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,    0,    0,    0,    0,    0,  -54,
+  168,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+    0,   47,  -64,    0,
 };
-#define YYTABLESIZE 299
+#define YYTABLESIZE 303
 static const short yytable[] = {                         50,
-   76,   46,   46,   71,   55,   77,   78,   53,   49,   49,
-   90,   91,   92,   54,   56,   57,   98,   95,   97,   72,
-   25,    3,   72,   54,  101,  102,  103,  104,  105,  106,
-   46,   72,   49,   46,    5,   53,    1,   49,    5,   94,
-   49,    5,    5,   96,    5,   55,    4,    4,    5,    5,
-    4,   77,   78,    4,    4,   55,    4,   11,  119,   10,
-    4,    4,  112,   10,   37,    5,   10,  126,    5,   10,
-    5,    5,   11,   10,   10,   57,   11,   12,  117,   11,
-    4,   17,   11,    4,    4,   57,   11,   11,    4,  124,
-   56,    4,   37,   10,    4,   37,   10,   18,    4,    4,
-   56,  132,  133,   28,   74,   75,   11,   29,   73,   11,
-   30,   73,   20,   31,   23,    4,   59,   32,   33,   86,
-   87,    4,   60,   60,   60,   58,   59,   25,   99,  100,
-   33,   33,   60,   60,   49,   58,   26,   60,   60,   47,
-   34,   60,   60,   60,   60,   60,   60,   52,   60,   77,
-   78,   60,   60,   53,   54,   60,   61,   61,   61,   33,
-  108,  109,   33,   55,   53,   53,   61,   61,   63,   65,
-   66,   61,   61,   56,   57,   61,   61,   61,   61,   61,
-   61,   73,   61,   67,   85,   61,   61,   88,  110,   61,
-   62,   62,   62,   53,  111,  113,   53,  115,  120,  122,
-   62,   62,  127,    9,  131,   62,   62,   17,   53,   62,
-   62,   62,   62,   62,   62,   53,   62,   47,   43,   62,
-   62,   44,    7,   62,   63,   63,   63,   24,   70,   46,
-  125,   89,    0,    0,   63,   63,    0,    0,    0,   63,
-   63,    0,    0,   63,   63,   63,   63,   63,   63,    0,
-   63,    0,    0,   63,   63,    0,    0,   63,   64,   64,
-   64,    0,    0,    0,    0,    0,    0,    0,   64,   64,
+   76,   86,   87,   47,   47,   71,   55,   50,   50,    1,
+   90,   91,   92,   54,   77,   78,   56,   57,   97,   34,
+   34,  108,  109,    3,  101,  102,  103,  104,  105,  106,
+    5,   50,   47,   72,    5,   47,   50,    5,    5,   50,
+    5,   54,    4,   96,    5,    5,    4,    4,   34,    4,
+    4,   34,    4,   54,   54,   38,    4,    4,  120,   10,
+    5,    5,   55,   10,    5,  115,   10,    5,  127,   10,
+   56,   11,   55,   10,   10,   12,    4,   11,  118,    4,
+   56,   11,   54,   38,   11,   54,   38,   11,   17,   49,
+  125,   11,   11,   10,    4,   18,   10,   58,    4,   74,
+   75,    4,  133,  134,    4,   57,   28,   58,    4,    4,
+   29,   11,   60,   30,   11,   57,   31,   20,   77,   78,
+   32,   33,   60,   99,  100,    4,   61,   61,   61,   98,
+   59,    4,   95,   77,   78,   25,   61,   61,   23,   25,
+   59,   61,   61,   34,  112,   61,   61,   61,   61,   61,
+   61,   26,   61,   53,   54,   61,   61,   63,   47,   61,
+   62,   62,   62,   55,   52,   73,   74,   65,   73,   74,
+   62,   62,   67,   56,   57,   62,   62,   66,   73,   62,
+   62,   62,   62,   62,   62,   85,   62,   88,  110,   62,
+   62,  111,  113,   62,   63,   63,   63,  116,  121,  123,
+  128,  132,   17,    9,   63,   63,   48,   54,   54,   63,
+   63,   44,   45,   63,   63,   63,   63,   63,   63,    7,
+   63,   24,   70,   63,   63,   46,  126,   63,   64,   64,
+   64,   89,    0,    0,    0,    0,    0,    0,   64,   64,
     0,    0,    0,   64,   64,    0,    0,   64,   64,   64,
-   64,   64,   64,    0,   64,    0,    0,   64,   64,   77,
-   78,   64,    0,   79,   80,   81,   82,   83,   84,
+   64,   64,   64,    0,   64,    0,    0,   64,   64,    0,
+    0,   64,   65,   65,   65,    0,    0,    0,    0,    0,
+    0,    0,   65,   65,    0,    0,    0,   65,   65,    0,
+    0,   65,   65,   65,   65,   65,   65,    0,   65,    0,
+    0,   65,   65,   77,   78,   65,    0,   79,   80,   81,
+   82,   83,   84,
 };
 static const short yycheck[] = {                         28,
-   55,  259,  260,  260,  283,  273,  274,  260,  259,  260,
-   65,   66,   67,  258,  293,  294,  284,  284,   73,  284,
-  287,  294,  287,  268,   79,   80,   81,   82,   83,   84,
-  288,  288,  283,  291,  257,  288,  266,  288,  261,   68,
-  291,  264,  265,   72,  267,  258,  257,  288,  271,  272,
-  261,  273,  274,  264,  265,  268,  267,  291,  113,  257,
-  271,  272,  284,  261,  260,  288,  264,  122,  291,  267,
-  270,  294,  257,  271,  272,  258,  261,  265,  107,  264,
-  291,  288,  267,  294,  257,  268,  271,  272,  261,  118,
-  258,  264,  288,  291,  267,  291,  294,  294,  271,  272,
-  268,  130,  131,  257,   53,   54,  291,  261,  284,  294,
-  264,  287,  294,  267,  288,  288,  258,  271,  272,  275,
-  276,  294,  258,  259,  260,  258,  268,  287,   77,   78,
-  259,  260,  268,  269,  283,  268,  288,  273,  274,  294,
-  294,  277,  278,  279,  280,  281,  282,  294,  284,  273,
-  274,  287,  288,  273,  274,  291,  258,  259,  260,  288,
-   86,   87,  291,  283,  259,  260,  268,  269,  283,  283,
-  292,  273,  274,  293,  294,  277,  278,  279,  280,  281,
-  282,  292,  284,  283,  268,  287,  288,  294,  284,  291,
-  258,  259,  260,  288,  258,  287,  291,  288,  284,  269,
-  268,  269,  259,  288,  258,  273,  274,  283,  291,  277,
-  278,  279,  280,  281,  282,  288,  284,  284,  269,  287,
-  288,  258,    4,  291,  258,  259,  260,   17,   49,   23,
-  121,   64,   -1,   -1,  268,  269,   -1,   -1,   -1,  273,
-  274,   -1,   -1,  277,  278,  279,  280,  281,  282,   -1,
-  284,   -1,   -1,  287,  288,   -1,   -1,  291,  258,  259,
-  260,   -1,   -1,   -1,   -1,   -1,   -1,   -1,  268,  269,
+   55,  275,  276,  259,  260,  260,  283,  259,  260,  266,
+   65,   66,   67,  260,  273,  274,  293,  294,   73,  259,
+  260,   86,   87,  294,   79,   80,   81,   82,   83,   84,
+  257,  283,  288,  288,  261,  291,  288,  264,  265,  291,
+  267,  288,  257,   72,  271,  272,  261,  288,  288,  264,
+  265,  291,  267,  259,  260,  260,  271,  272,  113,  257,
+  270,  288,  258,  261,  291,   94,  264,  294,  123,  267,
+  258,  291,  268,  271,  272,  265,  291,  257,  107,  294,
+  268,  261,  288,  288,  264,  291,  291,  267,  288,  283,
+  119,  271,  272,  291,  257,  294,  294,  258,  261,   53,
+   54,  264,  131,  132,  267,  258,  257,  268,  271,  272,
+  261,  291,  258,  264,  294,  268,  267,  294,  273,  274,
+  271,  272,  268,   77,   78,  288,  258,  259,  260,  284,
+  258,  294,  284,  273,  274,  287,  268,  269,  288,  287,
+  268,  273,  274,  294,  284,  277,  278,  279,  280,  281,
+  282,  288,  284,  273,  274,  287,  288,  283,  294,  291,
+  258,  259,  260,  283,  294,  284,  284,  283,  287,  287,
+  268,  269,  283,  293,  294,  273,  274,  292,  292,  277,
+  278,  279,  280,  281,  282,  268,  284,  294,  284,  287,
+  288,  258,  287,  291,  258,  259,  260,  288,  284,  269,
+  259,  258,  283,  288,  268,  269,  284,  291,  288,  273,
+  274,  269,  258,  277,  278,  279,  280,  281,  282,    4,
+  284,   17,   49,  287,  288,   23,  122,  291,  258,  259,
+  260,   64,   -1,   -1,   -1,   -1,   -1,   -1,  268,  269,
    -1,   -1,   -1,  273,  274,   -1,   -1,  277,  278,  279,
-  280,  281,  282,   -1,  284,   -1,   -1,  287,  288,  273,
-  274,  291,   -1,  277,  278,  279,  280,  281,  282,
+  280,  281,  282,   -1,  284,   -1,   -1,  287,  288,   -1,
+   -1,  291,  258,  259,  260,   -1,   -1,   -1,   -1,   -1,
+   -1,   -1,  268,  269,   -1,   -1,   -1,  273,  274,   -1,
+   -1,  277,  278,  279,  280,  281,  282,   -1,  284,   -1,
+   -1,  287,  288,  273,  274,  291,   -1,  277,  278,  279,
+  280,  281,  282,
 };
 #define YYFINAL 2
 #ifndef YYDEBUG
@@ -320,7 +357,8 @@ static const char *yyrule[] = {
 "$$5 :",
 "proc_decl : PROCEDURE proc_name $$4 LPAREN id_list RPAREN SEMICOLON $$5 inblock",
 "proc_name : IDENT",
-"inblock : var_decl_part statement",
+"$$6 :",
+"inblock : var_decl_part $$6 statement",
 "statement_list : statement_list SEMICOLON statement",
 "statement_list : statement",
 "statement : assignment_statement",
@@ -333,21 +371,21 @@ static const char *yyrule[] = {
 "statement : read_statement",
 "statement : write_statement",
 "assignment_statement : IDENT ASSIGN expression",
-"$$6 :",
 "$$7 :",
-"if_statement : IF condition THEN $$6 statement $$7 else_statement",
-"else_statement :",
 "$$8 :",
-"else_statement : ELSE $$8 statement",
+"if_statement : IF condition THEN $$7 statement $$8 else_statement",
+"else_statement :",
 "$$9 :",
+"else_statement : ELSE $$9 statement",
 "$$10 :",
-"while_statement : WHILE $$9 condition DO $$10 statement",
 "$$11 :",
+"while_statement : WHILE $$10 condition DO $$11 statement",
 "$$12 :",
-"for_statement : FOR IDENT ASSIGN expression $$11 TO expression $$12 DO statement",
-"proc_call_statement : proc_call_name",
 "$$13 :",
-"proc_call_statement : proc_call_name LPAREN arg_list $$13 RPAREN",
+"for_statement : FOR IDENT ASSIGN expression $$12 TO expression $$13 DO statement",
+"proc_call_statement : proc_call_name",
+"$$14 :",
+"proc_call_statement : proc_call_name LPAREN arg_list $$14 RPAREN",
 "proc_call_name : IDENT",
 "block_statement : SBEGIN statement_list SEND",
 "read_statement : READ LPAREN IDENT RPAREN",
@@ -412,7 +450,7 @@ typedef struct {
 } YYSTACKDATA;
 /* variables for the parser stack */
 static YYSTACKDATA yystack;
-#line 400 "parser.y"
+#line 456 "parser.y"
 
 
 yyerror(char *s)
@@ -426,7 +464,7 @@ yyerror(char *s)
                 s, yylineno, yytext
         );
 }
-#line 429 "y.tab.c"
+#line 467 "y.tab.c"
 
 #if YYDEBUG
 #include <stdio.h>		/* needed for printf */
@@ -633,16 +671,15 @@ yyreduce:
     switch (yyn)
     {
 case 1:
-#line 61 "parser.y"
+#line 96 "parser.y"
 	{
         if ((fp = fopen(filename, "w")) == NULL) return EXIT_FAILURE;
         display_llvm();
         fclose(fp);
-        /*debug_symbol_table();*/
         }
 break;
 case 2:
-#line 70 "parser.y"
+#line 104 "parser.y"
 	{
         insert_decl("main", 0, NULL);
         Factor x = {CONSTANT, "1", 0};
@@ -654,7 +691,7 @@ case 2:
         }
 break;
 case 3:
-#line 79 "parser.y"
+#line 113 "parser.y"
 	{
         back_patch();
         /*insert_code(Load);*/
@@ -662,115 +699,128 @@ case 3:
         }
 break;
 case 8:
-#line 97 "parser.y"
+#line 131 "parser.y"
 	{
         var_mode = TRUE;
         }
 break;
 case 9:
-#line 99 "parser.y"
+#line 133 "parser.y"
 	{
         var_mode = FALSE;
-        /*VARの時はただちに記号表を正しい値に書き換える*/
-        /*引数の時はAllocaとかをしてから書き換えないといけない*/
-        overwrite_symbol_val(count);
         }
 break;
 case 15:
-#line 122 "parser.y"
+#line 153 "parser.y"
 	{
         scope = LOCAL_VAR;
         count = 0;
+        var_num = 0;
+        arity_num = 0;
         insert_symbol(PROC_NAME, yystack.l_mark[-1].ident, 0);
         insert_decl(yystack.l_mark[-1].ident, 0, NULL);
         reg_counter = count + 1;
-        insert_code(Alloca);
-        overwrite_symbol_val(count + 1);
+        count++;
         }
 break;
 case 16:
-#line 131 "parser.y"
+#line 163 "parser.y"
 	{
         back_patch();
-        /*debug_symbol_table();*/
         delete_local_symbol();
         scope = GLOBAL_VAR;
         }
 break;
 case 17:
-#line 138 "parser.y"
+#line 169 "parser.y"
 	{
         scope = LOCAL_VAR;
         count = 0;
         insert_symbol(PROC_NAME, yystack.l_mark[0].ident, count);
-        var_mode = TRUE;
+        arity_mode = TRUE;
         }
 break;
 case 18:
-#line 143 "parser.y"
+#line 174 "parser.y"
 	{
-                var_mode = FALSE;
+                arity_mode = FALSE;
                 /*レジスタの値は返り値分一つ増やしておく*/
-                /*count: 引数の個数*/
-                /*reg_counter: 引数(n個),返り値(1個),中身(m個)の順に番号づけされる*/
-                reg_counter = count + 1;
+                /*reg_counter: 引数(n個),返り値(1個),局所変数(m個), 中身(k個)の順に番号づけされる*/
                 insert_decl(yystack.l_mark[-5].ident, count, NULL);
-                for (i = 0; i < count; i++) {
-                        insert_code(Alloca);
-                }
-                for (i = 0; i < count; i++) {
-                        insert_code(Store);
-                }
-                /*記号表のアドレスの更新,新しいlocal varを突っ込む,引数は全てlocalだから上書きオッケー*/
-                overwrite_symbol_val(count + 1);
+                reg_counter = count + 1;
+                count++;
         }
 break;
 case 19:
-#line 159 "parser.y"
+#line 182 "parser.y"
 	{
         back_patch();
-        /*debug_symbol_table();*/
         delete_local_symbol();
         scope = GLOBAL_VAR;
         }
 break;
-case 33:
-#line 193 "parser.y"
+case 21:
+#line 197 "parser.y"
+	{
+                for (i = 0; i < var_num + arity_num; i++) {
+                        tmp1_element[i] = factor_pop();
+                        tmp1_top++;
+                }
+                for (i = 0; i < var_num + arity_num; i++) {
+                        insert_code(Alloca);
+                }
+                for (i = 0; i < var_num + arity_num; i++) {
+                        tmp2_element[i] = factor_pop();
+                        tmp2_top++;
+                }
+                for (i = var_num + arity_num ; i > var_num; i--) {
+                        factor_push(tmp1_element[i-1]);
+                        factor_push(tmp2_element[i-1]);
+                        insert_code(Store);
+                }
+                tmp1_top = 0;
+                tmp2_top = 0;
+                /*記号表のアドレスの更新,新しいlocal varを突っ込む,引数は全てlocalだから上書きオッケー*/
+                overwrite_symbol_val(var_num, arity_num);
+        }
+break;
+case 34:
+#line 239 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
         insert_code(Store);
         }
 break;
-case 34:
-#line 201 "parser.y"
+case 35:
+#line 247 "parser.y"
 	{
         insert_code(BrCond);
         insert_code(Label);
         }
 break;
-case 35:
-#line 205 "parser.y"
+case 36:
+#line 251 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
         }
 break;
-case 37:
-#line 213 "parser.y"
+case 38:
+#line 259 "parser.y"
 	{
         label_push(reg_counter);
-        insert_code(Label);
-        }
-break;
-case 38:
-#line 217 "parser.y"
-	{
         insert_code(Label);
         }
 break;
 case 39:
-#line 220 "parser.y"
+#line 263 "parser.y"
+	{
+        insert_code(Label);
+        }
+break;
+case 40:
+#line 266 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -778,8 +828,8 @@ case 39:
         insert_code(Label);
         }
 break;
-case 40:
-#line 229 "parser.y"
+case 41:
+#line 275 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -787,15 +837,15 @@ case 40:
         insert_code(Label);
         }
 break;
-case 41:
-#line 235 "parser.y"
+case 42:
+#line 281 "parser.y"
 	{
         insert_code(BrCond);
         insert_code(Label);
         }
 break;
-case 42:
-#line 239 "parser.y"
+case 43:
+#line 285 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -803,8 +853,8 @@ case 42:
         insert_code(Label);
         }
 break;
-case 43:
-#line 248 "parser.y"
+case 44:
+#line 294 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
@@ -817,8 +867,8 @@ case 43:
         insert_code(Load);
         }
 break;
-case 44:
-#line 259 "parser.y"
+case 45:
+#line 305 "parser.y"
 	{
         set_cmp_type(SLE);
         insert_code(Icmp);
@@ -826,8 +876,8 @@ case 44:
         insert_code(Label);
         }
 break;
-case 45:
-#line 265 "parser.y"
+case 46:
+#line 311 "parser.y"
 	{
         insert_code(BrUncond);
         tmp2 = reg_counter;
@@ -848,24 +898,24 @@ case 45:
         insert_code(Label);
         }
 break;
-case 46:
-#line 287 "parser.y"
+case 47:
+#line 333 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[0].ident);
         factor_push(x);
         insert_code(Proc);
         }
 break;
-case 47:
-#line 292 "parser.y"
+case 48:
+#line 338 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
         insert_code(Proc);
         }
 break;
-case 51:
-#line 308 "parser.y"
+case 52:
+#line 354 "parser.y"
 	{
         set_read_flag(TRUE);
         Factor x = create_factor_by_name(yystack.l_mark[-1].ident);
@@ -873,62 +923,62 @@ case 51:
         insert_code(Read);
         }
 break;
-case 52:
-#line 317 "parser.y"
+case 53:
+#line 363 "parser.y"
 	{
         set_write_flag(TRUE);
         insert_code(Write);
         }
 break;
-case 54:
-#line 328 "parser.y"
+case 55:
+#line 374 "parser.y"
 	{set_cmp_type(EQUAL); insert_code(Icmp);}
 break;
-case 55:
-#line 329 "parser.y"
+case 56:
+#line 375 "parser.y"
 	{set_cmp_type(NE); insert_code(Icmp);}
 break;
-case 56:
-#line 330 "parser.y"
+case 57:
+#line 376 "parser.y"
 	{set_cmp_type(SLT); insert_code(Icmp);}
 break;
-case 57:
-#line 331 "parser.y"
+case 58:
+#line 377 "parser.y"
 	{set_cmp_type(SLE); insert_code(Icmp);}
 break;
-case 58:
-#line 332 "parser.y"
+case 59:
+#line 378 "parser.y"
 	{set_cmp_type(SGT); insert_code(Icmp);}
 break;
-case 59:
-#line 333 "parser.y"
+case 60:
+#line 379 "parser.y"
 	{set_cmp_type(SGE); insert_code(Icmp);}
 break;
-case 63:
-#line 340 "parser.y"
+case 64:
+#line 386 "parser.y"
 	{insert_code(Add);}
 break;
-case 64:
-#line 341 "parser.y"
+case 65:
+#line 387 "parser.y"
 	{insert_code(Sub);}
 break;
-case 66:
-#line 346 "parser.y"
+case 67:
+#line 392 "parser.y"
 	{insert_code(Mult);}
 break;
-case 67:
-#line 347 "parser.y"
+case 68:
+#line 393 "parser.y"
 	{insert_code(Div);}
 break;
-case 69:
-#line 352 "parser.y"
+case 70:
+#line 398 "parser.y"
 	{
         Factor x = {CONSTANT, "", yystack.l_mark[0].num};
         factor_push(x);
         }
 break;
-case 71:
-#line 360 "parser.y"
+case 72:
+#line 406 "parser.y"
 	{
         /*ここの記号表に各処理をいじらないとだめそう*/
         /*記号表のvalの値を書き換えていく*/
@@ -937,16 +987,8 @@ case 71:
         insert_code(Load);
         }
 break;
-case 72:
-#line 370 "parser.y"
-	{
-        Factor x = factor_pop();
-        arity_push(x);
-        factor_push(x);
-        }
-break;
 case 73:
-#line 375 "parser.y"
+#line 416 "parser.y"
 	{
         Factor x = factor_pop();
         arity_push(x);
@@ -954,26 +996,44 @@ case 73:
         }
 break;
 case 74:
-#line 383 "parser.y"
+#line 421 "parser.y"
 	{
-        if (var_mode) {
-                insert_symbol(scope, yystack.l_mark[0].ident, count++);
-        }
-        Factor x = create_factor_by_name(yystack.l_mark[0].ident);
+        Factor x = factor_pop();
+        arity_push(x);
         factor_push(x);
         }
 break;
 case 75:
-#line 390 "parser.y"
+#line 429 "parser.y"
 	{
         if (var_mode) {
+                if (scope == LOCAL_VAR) var_num++;
+                insert_symbol(scope, yystack.l_mark[0].ident, count++);
+        }
+        if (arity_mode) {
+                arity_num++;
                 insert_symbol(scope, yystack.l_mark[0].ident, count++);
         }
         Factor x = create_factor_by_name(yystack.l_mark[0].ident);
         factor_push(x);
         }
 break;
-#line 976 "y.tab.c"
+case 76:
+#line 441 "parser.y"
+	{
+        if (var_mode) {
+                if (scope == LOCAL_VAR) var_num++;
+                insert_symbol(scope, yystack.l_mark[0].ident, count++);
+        }
+        if (arity_mode) {
+                arity_num++;
+                insert_symbol(scope, yystack.l_mark[0].ident, count++);
+        }
+        Factor x = create_factor_by_name(yystack.l_mark[0].ident);
+        factor_push(x);
+        }
+break;
+#line 1036 "y.tab.c"
     }
     yystack.s_mark -= yym;
     yystate = *yystack.s_mark;

--- a/parser.y
+++ b/parser.y
@@ -168,6 +168,9 @@ proc_name
         : IDENT
         ;
 
+
+
+
 inblock
         : var_decl_part statement
         ;

--- a/parser.y
+++ b/parser.y
@@ -27,6 +27,41 @@ int tmp1,tmp2, tmp3;
 int arity = 0;
 int i = 0;
 int var_mode = FALSE;
+int arity_mode = FALSE;
+
+int var_num = 0;
+int arity_num = 0;
+
+Factor tmp1_element[100];
+int tmp1_top = 0;
+
+Factor tmp2_element[100];
+int tmp2_top = 0;
+
+void debug_tmp1() {
+        printf("\ntmp1 debug\n");
+        printf("|-----------------------|\n");
+        printf("| type\t| name\t| val\t|\n");
+        printf("|-----------------------|\n");
+
+        for (i = 0; i < tmp1_top; i++) {
+        Factor x = tmp1_element[i];
+        printf("| %d\t| %s\t| %d\t|\n", x.type, x.name,x.val);
+        }
+  printf("|-----------------------|\n");
+}
+void debug_tmp2() {
+        printf("\ntmp2 debug\n");
+        printf("|-----------------------|\n");
+        printf("| type\t| name\t| val\t|\n");
+        printf("|-----------------------|\n");
+
+        for (i = 0; i < tmp2_top; i++) {
+        Factor x = tmp2_element[i];
+        printf("| %d\t| %s\t| %d\t|\n", x.type, x.name,x.val);
+        }
+  printf("|-----------------------|\n");
+}
 
 
 %}
@@ -62,7 +97,6 @@ program
         if ((fp = fopen(filename, "w")) == NULL) return EXIT_FAILURE;
         display_llvm();
         fclose(fp);
-        //debug_symbol_table();
         }
         ;
 
@@ -98,9 +132,6 @@ var_decl
         var_mode = TRUE;
         } id_list {
         var_mode = FALSE;
-        //VARの時はただちに記号表を正しい値に書き換える
-        //引数の時はAllocaとかをしてから書き換えないといけない
-        overwrite_symbol_val(count);
         }
         ;
 
@@ -125,12 +156,10 @@ proc_decl
         insert_symbol(PROC_NAME, $2, 0);
         insert_decl($2, 0, NULL);
         reg_counter = count + 1;
-        insert_code(Alloca);
-        overwrite_symbol_val(count + 1);
+        count++;
         }
         inblock {
         back_patch();
-        //debug_symbol_table();
         delete_local_symbol();
         scope = GLOBAL_VAR;
         }
@@ -139,26 +168,17 @@ proc_decl
         scope = LOCAL_VAR;
         count = 0;
         insert_symbol(PROC_NAME, $2, count);
-        var_mode = TRUE;
+        arity_mode = TRUE;
         } LPAREN id_list RPAREN SEMICOLON {
-                var_mode = FALSE;
+                arity_mode = FALSE;
                 //レジスタの値は返り値分一つ増やしておく
-                //count: 引数の個数
-                //reg_counter: 引数(n個),返り値(1個),中身(m個)の順に番号づけされる
-                reg_counter = count + 1;
+                //reg_counter: 引数(n個),返り値(1個),局所変数(m個), 中身(k個)の順に番号づけされる
                 insert_decl($2, count, NULL);
-                for (i = 0; i < count; i++) {
-                        insert_code(Alloca);
-                }
-                for (i = 0; i < count; i++) {
-                        insert_code(Store);
-                }
-                //記号表のアドレスの更新,新しいlocal varを突っ込む,引数は全てlocalだから上書きオッケー
-                overwrite_symbol_val(count + 1);
+                reg_counter = count + 1;
+                count++;
         }
         inblock {
         back_patch();
-        //debug_symbol_table();
         delete_local_symbol();
         scope = GLOBAL_VAR;
         }
@@ -172,7 +192,28 @@ proc_name
 
 
 inblock
-        : var_decl_part statement
+        : var_decl_part {
+                for (i = 0; i < var_num + arity_num; i++) {
+                        tmp1_element[i] = factor_pop();
+                        tmp1_top++;
+                }
+                for (i = 0; i < var_num + arity_num; i++) {
+                        insert_code(Alloca);
+                }
+                for (i = 0; i < var_num + arity_num; i++) {
+                        tmp2_element[i] = factor_pop();
+                        tmp2_top++;
+                }
+                for (i = var_num + arity_num ; i > var_num; i--) {
+                        factor_push(tmp1_element[i-1]);
+                        factor_push(tmp2_element[i-1]);
+                        insert_code(Store);
+                }
+                tmp1_top = 0;
+                tmp2_top = 0;
+                //記号表のアドレスの更新,新しいlocal varを突っ込む,引数は全てlocalだから上書きオッケー
+                overwrite_symbol_val(var_num, arity_num);
+        } statement
         ;
 
 statement_list
@@ -385,6 +426,11 @@ arg_list
 id_list
         : IDENT {
         if (var_mode) {
+                if (scope == LOCAL_VAR) var_num++;
+                insert_symbol(scope, $1, count++);
+        }
+        if (arity_mode) {
+                arity_num++;
                 insert_symbol(scope, $1, count++);
         }
         Factor x = create_factor_by_name($1);
@@ -392,6 +438,11 @@ id_list
         }
         | id_list COMMA IDENT {
         if (var_mode) {
+                if (scope == LOCAL_VAR) var_num++;
+                insert_symbol(scope, $3, count++);
+        }
+        if (arity_mode) {
+                arity_num++;
                 insert_symbol(scope, $3, count++);
         }
         Factor x = create_factor_by_name($3);

--- a/parser.y
+++ b/parser.y
@@ -153,6 +153,8 @@ proc_decl
         : PROCEDURE proc_name SEMICOLON {
         scope = LOCAL_VAR;
         count = 0;
+        var_num = 0;
+        arity_num = 0;
         insert_symbol(PROC_NAME, $2, 0);
         insert_decl($2, 0, NULL);
         reg_counter = count + 1;

--- a/result.ll
+++ b/result.ll
@@ -41,12 +41,22 @@ define void @fact(i32, i32) #0 {
   ret void
 }
 
+define void @test() #0 {
+  %1 = alloca i32, align 4
+  store i32 0, i32* %1, align 4
+  %2 = load i32, i32* %1, align 4
+  %3 = add nsw i32 %2, 1
+  store i32 %3, i32* %1, align 4
+  ret void
+}
+
 define i32 @main() #0 {
   %1 = alloca i32, align 4
   store i32 0, i32* %1, align 4
   %2 = call i32 (i8*, ...) @__isoc99_scanf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32* @n)
   %3 = load i32, i32* @n, align 4
   call void @fact(i32 %3, i32 1)
+  call void @test()
   %4 = load i32, i32* @temp, align 4
   %5 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32 %4)
   ret i32 0

--- a/result.ll
+++ b/result.ll
@@ -5,28 +5,31 @@
 declare dso_local i32 @__isoc99_scanf(i8*, ...) #1
 declare dso_local i32 @printf(i8*, ...) #1
 
-define void @fact(i32) #0 {
-  %2 = alloca i32, align 4
-  store i32 %0, i32* %2, align 4
-  %3 = load i32, i32* %2, align 4
-  %4 = icmp sle i32 %3, 1
-  br i1 %4, label %5, label %6
+define void @fact(i32, i32) #0 {
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  store i32 %3, i32* %4, align 4
+  store i32 %1, i32* %4, align 4
+  %5 = load i32, i32* %2, align 4
+  %6 = icmp sle i32 %5, 1
+  br i1 %6, label %7, label %8
 
-5:
+7:
   store i32 1, i32* @temp, align 4
-  br label %12
+  br label %15
 
-6:
-  %7 = load i32, i32* %2, align 4
-  %8 = sub nsw i32 %7, 1
-  call void @fact(i32 %8)
-  %9 = load i32, i32* @temp, align 4
-  %10 = load i32, i32* %2, align 4
-  %11 = mul nsw i32 %9, %10
-  store i32 %11, i32* @temp, align 4
-  br label %12
+8:
+  %9 = load i32, i32* %2, align 4
+  %10 = sub nsw i32 %9, 1
+  %11 = load i32, i32* %3, align 4
+  call void @fact(i32 %10, i32 %11)
+  %12 = load i32, i32* @temp, align 4
+  %13 = load i32, i32* %2, align 4
+  %14 = mul nsw i32 %12, %13
+  store i32 %14, i32* @temp, align 4
+  br label %15
 
-12:
+15:
   ret void
 }
 
@@ -35,7 +38,7 @@ define i32 @main() #0 {
   store i32 0, i32* %1, align 4
   %2 = call i32 (i8*, ...) @__isoc99_scanf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32* @n)
   %3 = load i32, i32* @n, align 4
-  call void @fact(i32 %3)
+  call void @fact(i32 %3, i32 1)
   %4 = load i32, i32* @temp, align 4
   %5 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32 %4)
   ret i32 0

--- a/result.ll
+++ b/result.ll
@@ -8,28 +8,36 @@ declare dso_local i32 @printf(i8*, ...) #1
 define void @fact(i32, i32) #0 {
   %3 = alloca i32, align 4
   %4 = alloca i32, align 4
-  store i32 %3, i32* %4, align 4
+  %5 = alloca i32, align 4
+  %6 = alloca i32, align 4
+  store i32 %0, i32* %3, align 4
   store i32 %1, i32* %4, align 4
-  %5 = load i32, i32* %2, align 4
-  %6 = icmp sle i32 %5, 1
-  br i1 %6, label %7, label %8
+  store i32 0, i32* %5, align 4
+  store i32 2, i32* %6, align 4
+  %7 = load i32, i32* %3, align 4
+  %8 = icmp sle i32 %7, 1
+  br i1 %8, label %9, label %10
 
-7:
+9:
   store i32 1, i32* @temp, align 4
-  br label %15
+  br label %21
 
-8:
-  %9 = load i32, i32* %2, align 4
-  %10 = sub nsw i32 %9, 1
+10:
   %11 = load i32, i32* %3, align 4
-  call void @fact(i32 %10, i32 %11)
-  %12 = load i32, i32* @temp, align 4
-  %13 = load i32, i32* %2, align 4
-  %14 = mul nsw i32 %12, %13
-  store i32 %14, i32* @temp, align 4
-  br label %15
+  %12 = sub nsw i32 %11, 1
+  %13 = load i32, i32* %4, align 4
+  %14 = load i32, i32* %5, align 4
+  %15 = add nsw i32 %13, %14
+  %16 = load i32, i32* %6, align 4
+  %17 = add nsw i32 %15, %16
+  call void @fact(i32 %12, i32 %17)
+  %18 = load i32, i32* @temp, align 4
+  %19 = load i32, i32* %3, align 4
+  %20 = mul nsw i32 %18, %19
+  store i32 %20, i32* @temp, align 4
+  br label %21
 
-15:
+21:
   ret void
 }
 

--- a/samples/c/pl1b.c
+++ b/samples/c/pl1b.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+
+int n, temp;
+
+void fact(int n, int m) {
+  if (n <= 1) {
+    temp = 1;
+  } else {
+    fact(n - 1, m);
+    temp = temp * n;
+  }
+  return;
+}
+
+int main() {
+  scanf("%d\n", &n);
+  fact(n, 1);
+  printf("%d\n", temp);
+  return 0;
+}

--- a/samples/c/pl1c.c
+++ b/samples/c/pl1c.c
@@ -5,6 +5,8 @@
 int n, temp;
 
 void fact(int n, int m) {
+  int k;
+  k = 0;
   if (n <= 1) {
     temp = 1;
   } else {

--- a/samples/c/pl1d.c
+++ b/samples/c/pl1d.c
@@ -17,9 +17,17 @@ void fact(int n, int m) {
   return;
 }
 
+void test() {
+  int k;
+  k = 0;
+  k = k + 1;
+  return;
+}
+
 int main() {
   scanf("%d\n", &n);
   fact(n, 1);
+  test();
   printf("%d\n", temp);
   return 0;
 }

--- a/samples/c/pl1d.c
+++ b/samples/c/pl1d.c
@@ -5,10 +5,13 @@
 int n, temp;
 
 void fact(int n, int m) {
+  int k, l;
+  k = 0;
+  l = 2;
   if (n <= 1) {
     temp = 1;
   } else {
-    fact(n - 1, m);
+    fact(n - 1, m + k + l);
     temp = temp * n;
   }
   return;

--- a/samples/llvm/pl1b.ll
+++ b/samples/llvm/pl1b.ll
@@ -1,0 +1,62 @@
+; ModuleID = './samples/c/pl1b.c'
+source_filename = "./samples/c/pl1b.c"
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@temp = common dso_local global i32 0, align 4
+@.str = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
+@n = common dso_local global i32 0, align 4
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local void @fact(i32, i32) #0 {
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  store i32 %0, i32* %3, align 4
+  store i32 %1, i32* %4, align 4
+  %5 = load i32, i32* %3, align 4
+  %6 = icmp sle i32 %5, 1
+  br i1 %6, label %7, label %8
+
+7:                                                ; preds = %2
+  store i32 1, i32* @temp, align 4
+  br label %15
+
+8:                                                ; preds = %2
+  %9 = load i32, i32* %3, align 4
+  %10 = sub nsw i32 %9, 1
+  %11 = load i32, i32* %4, align 4
+  call void @fact(i32 %10, i32 %11)
+  %12 = load i32, i32* @temp, align 4
+  %13 = load i32, i32* %3, align 4
+  %14 = mul nsw i32 %12, %13
+  store i32 %14, i32* @temp, align 4
+  br label %15
+
+15:                                               ; preds = %8, %7
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+  %1 = alloca i32, align 4
+  store i32 0, i32* %1, align 4
+  %2 = call i32 (i8*, ...) @__isoc99_scanf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32* @n)
+  %3 = load i32, i32* @n, align 4
+  call void @fact(i32 %3, i32 1)
+  %4 = load i32, i32* @temp, align 4
+  %5 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32 %4)
+  ret i32 0
+}
+
+declare dso_local i32 @__isoc99_scanf(i8*, ...) #1
+
+declare dso_local i32 @printf(i8*, ...) #1
+
+attributes #0 = { noinline nounwind optnone uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 9.0.0 (Red Hat 9.0.0-1.el7)"}

--- a/samples/llvm/pl1c.ll
+++ b/samples/llvm/pl1c.ll
@@ -1,0 +1,64 @@
+; ModuleID = './samples/c/pl1c.c'
+source_filename = "./samples/c/pl1c.c"
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@temp = common dso_local global i32 0, align 4
+@.str = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
+@n = common dso_local global i32 0, align 4
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local void @fact(i32, i32) #0 {
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  %5 = alloca i32, align 4
+  store i32 %0, i32* %3, align 4
+  store i32 %1, i32* %4, align 4
+  store i32 0, i32* %5, align 4
+  %6 = load i32, i32* %3, align 4
+  %7 = icmp sle i32 %6, 1
+  br i1 %7, label %8, label %9
+
+8:                                                ; preds = %2
+  store i32 1, i32* @temp, align 4
+  br label %16
+
+9:                                                ; preds = %2
+  %10 = load i32, i32* %3, align 4
+  %11 = sub nsw i32 %10, 1
+  %12 = load i32, i32* %4, align 4
+  call void @fact(i32 %11, i32 %12)
+  %13 = load i32, i32* @temp, align 4
+  %14 = load i32, i32* %3, align 4
+  %15 = mul nsw i32 %13, %14
+  store i32 %15, i32* @temp, align 4
+  br label %16
+
+16:                                               ; preds = %9, %8
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+  %1 = alloca i32, align 4
+  store i32 0, i32* %1, align 4
+  %2 = call i32 (i8*, ...) @__isoc99_scanf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32* @n)
+  %3 = load i32, i32* @n, align 4
+  call void @fact(i32 %3, i32 1)
+  %4 = load i32, i32* @temp, align 4
+  %5 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32 %4)
+  ret i32 0
+}
+
+declare dso_local i32 @__isoc99_scanf(i8*, ...) #1
+
+declare dso_local i32 @printf(i8*, ...) #1
+
+attributes #0 = { noinline nounwind optnone uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 9.0.0 (Red Hat 9.0.0-1.el7)"}

--- a/samples/llvm/pl1d.ll
+++ b/samples/llvm/pl1d.ll
@@ -1,0 +1,70 @@
+; ModuleID = './samples/c/pl1d.c'
+source_filename = "./samples/c/pl1d.c"
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@temp = common dso_local global i32 0, align 4
+@.str = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
+@n = common dso_local global i32 0, align 4
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local void @fact(i32, i32) #0 {
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  %5 = alloca i32, align 4
+  %6 = alloca i32, align 4
+  store i32 %0, i32* %3, align 4
+  store i32 %1, i32* %4, align 4
+  store i32 0, i32* %5, align 4
+  store i32 2, i32* %6, align 4
+  %7 = load i32, i32* %3, align 4
+  %8 = icmp sle i32 %7, 1
+  br i1 %8, label %9, label %10
+
+9:                                                ; preds = %2
+  store i32 1, i32* @temp, align 4
+  br label %21
+
+10:                                               ; preds = %2
+  %11 = load i32, i32* %3, align 4
+  %12 = sub nsw i32 %11, 1
+  %13 = load i32, i32* %4, align 4
+  %14 = load i32, i32* %5, align 4
+  %15 = add nsw i32 %13, %14
+  %16 = load i32, i32* %6, align 4
+  %17 = add nsw i32 %15, %16
+  call void @fact(i32 %12, i32 %17)
+  %18 = load i32, i32* @temp, align 4
+  %19 = load i32, i32* %3, align 4
+  %20 = mul nsw i32 %18, %19
+  store i32 %20, i32* @temp, align 4
+  br label %21
+
+21:                                               ; preds = %10, %9
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+  %1 = alloca i32, align 4
+  store i32 0, i32* %1, align 4
+  %2 = call i32 (i8*, ...) @__isoc99_scanf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32* @n)
+  %3 = load i32, i32* @n, align 4
+  call void @fact(i32 %3, i32 1)
+  %4 = load i32, i32* @temp, align 4
+  %5 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32 %4)
+  ret i32 0
+}
+
+declare dso_local i32 @__isoc99_scanf(i8*, ...) #1
+
+declare dso_local i32 @printf(i8*, ...) #1
+
+attributes #0 = { noinline nounwind optnone uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 9.0.0 (Red Hat 9.0.0-1.el7)"}

--- a/samples/llvm/pl1d.ll
+++ b/samples/llvm/pl1d.ll
@@ -45,12 +45,23 @@ define dso_local void @fact(i32, i32) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
+define dso_local void @test() #0 {
+  %1 = alloca i32, align 4
+  store i32 0, i32* %1, align 4
+  %2 = load i32, i32* %1, align 4
+  %3 = add nsw i32 %2, 1
+  store i32 %3, i32* %1, align 4
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() #0 {
   %1 = alloca i32, align 4
   store i32 0, i32* %1, align 4
   %2 = call i32 (i8*, ...) @__isoc99_scanf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32* @n)
   %3 = load i32, i32* @n, align 4
   call void @fact(i32 %3, i32 1)
+  call void @test()
   %4 = load i32, i32* @temp, align 4
   %5 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str, i64 0, i64 0), i32 %4)
   ret i32 0

--- a/samples/pascal/pl1b.p
+++ b/samples/pascal/pl1b.p
@@ -1,0 +1,17 @@
+program PL1A;
+var n, temp;
+procedure fact(n, m);
+begin
+      if n <= 1 then
+	 temp:=1
+      else
+      begin
+	 fact(n - 1, m);
+	 temp := temp * n
+      end
+end;
+begin
+   read(n);
+   fact(n, 1);
+   write(temp)
+end.

--- a/samples/pascal/pl1c.p
+++ b/samples/pascal/pl1c.p
@@ -1,0 +1,19 @@
+program PL1A;
+var n, temp;
+procedure fact(n, m);
+var k;
+begin
+    k := 0;
+      if n <= 1 then
+	 temp:=1
+      else
+      begin
+	 fact(n - 1, m);
+	 temp := temp * n
+      end
+end;
+begin
+   read(n);
+   fact(n, 1);
+   write(temp)
+end.

--- a/samples/pascal/pl1d.p
+++ b/samples/pascal/pl1d.p
@@ -1,0 +1,20 @@
+program PL1A;
+var n, temp;
+procedure fact(n, m);
+var k, l;
+begin
+    k := 0;
+    l := 2;
+      if n <= 1 then
+	 temp:=1
+      else
+      begin
+	 fact(n - 1, m + k + l);
+	 temp := temp * n
+      end
+end;
+begin
+   read(n);
+   fact(n, 1);
+   write(temp)
+end.

--- a/samples/pascal/pl1d.p
+++ b/samples/pascal/pl1d.p
@@ -13,8 +13,15 @@ begin
 	 temp := temp * n
       end
 end;
+procedure test;
+var k;
+begin
+   k := 0;
+   k := k + 1;
+end;
 begin
    read(n);
    fact(n, 1);
+   test;
    write(temp)
 end.

--- a/symbol-table.c
+++ b/symbol-table.c
@@ -91,7 +91,7 @@ Symbol *get_symbol_head_ptr() { return symbol_head_ptr; }
 void debug_symbol_table() {
   Symbol *symbol_ptr = (Symbol *)malloc(sizeof(Symbol));
   symbol_ptr = symbol_tail_ptr;
-
+  printf("\nsymbol_table debug\n");
   printf("|-----------------------|\n");
   printf("| type\t| name\t| val\t|\n");
   printf("|-----------------------|\n");
@@ -107,12 +107,13 @@ void debug_symbol_table() {
   return;
 };
 
-void overwrite_symbol_val(int count) {
+void overwrite_symbol_val(int var_num, int arity_num) {
+  int tmp = arity_num * 2 + var_num;
   Symbol *symbol_ptr = (Symbol *)malloc(sizeof(Symbol));
   symbol_ptr = symbol_tail_ptr;
 
-  while (symbol_ptr && count > 0) {
-    symbol_ptr->val = count--;
+  while (symbol_ptr && tmp > arity_num) {
+    if (symbol_ptr->type == LOCAL_VAR) symbol_ptr->val = tmp--;
     symbol_ptr = symbol_ptr->prev;
   }
 

--- a/y.tab.c
+++ b/y.tab.c
@@ -45,9 +45,44 @@ int tmp1,tmp2, tmp3;
 int arity = 0;
 int i = 0;
 int var_mode = FALSE;
+int arity_mode = FALSE;
+
+int var_num = 0;
+int arity_num = 0;
+
+Factor tmp1_element[100];
+int tmp1_top = 0;
+
+Factor tmp2_element[100];
+int tmp2_top = 0;
+
+void debug_tmp1() {
+        printf("\ntmp1 debug\n");
+        printf("|-----------------------|\n");
+        printf("| type\t| name\t| val\t|\n");
+        printf("|-----------------------|\n");
+
+        for (i = 0; i < tmp1_top; i++) {
+        Factor x = tmp1_element[i];
+        printf("| %d\t| %s\t| %d\t|\n", x.type, x.name,x.val);
+        }
+  printf("|-----------------------|\n");
+}
+void debug_tmp2() {
+        printf("\ntmp2 debug\n");
+        printf("|-----------------------|\n");
+        printf("| type\t| name\t| val\t|\n");
+        printf("|-----------------------|\n");
+
+        for (i = 0; i < tmp2_top; i++) {
+        Factor x = tmp2_element[i];
+        printf("| %d\t| %s\t| %d\t|\n", x.type, x.name,x.val);
+        }
+  printf("|-----------------------|\n");
+}
 
 
-#line 34 "parser.y"
+#line 69 "parser.y"
 #ifdef YYSTYPE
 #undef  YYSTYPE_IS_DECLARED
 #define YYSTYPE_IS_DECLARED 1
@@ -59,7 +94,7 @@ typedef union {
     char ident[MAXLENGTH+1];
 } YYSTYPE;
 #endif /* !YYSTYPE_IS_DECLARED */
-#line 62 "y.tab.c"
+#line 97 "y.tab.c"
 
 /* compatibility with bison */
 #ifdef YYPARSE_PARAM
@@ -134,149 +169,151 @@ extern int YYPARSE_DECL();
 static const short yylhs[] = {                           -1,
     0,    7,    3,    4,    4,    8,    8,   11,    9,    5,
     5,   12,   12,   13,   16,   14,   17,   18,   14,    1,
-   15,   19,   19,    6,    6,    6,    6,    6,    6,    6,
-    6,    6,   20,   31,   33,   21,   32,   34,   32,   35,
-   36,   22,   37,   38,   23,   24,   40,   24,    2,   26,
-   27,   28,   25,   30,   30,   30,   30,   30,   30,   29,
-   29,   29,   29,   29,   41,   41,   41,   42,   42,   42,
-   43,   39,   39,   10,   10,
+   19,   15,   20,   20,    6,    6,    6,    6,    6,    6,
+    6,    6,    6,   21,   32,   34,   22,   33,   35,   33,
+   36,   37,   23,   38,   39,   24,   25,   41,   25,    2,
+   27,   28,   29,   26,   31,   31,   31,   31,   31,   31,
+   30,   30,   30,   30,   30,   42,   42,   42,   43,   43,
+   43,   44,   40,   40,   10,   10,
 };
 static const short yylen[] = {                            2,
     5,    0,    4,    0,    2,    3,    1,    0,    3,    0,
     2,    3,    1,    1,    0,    5,    0,    0,    9,    1,
-    2,    3,    1,    1,    1,    1,    1,    1,    1,    1,
-    1,    1,    3,    0,    0,    7,    0,    0,    3,    0,
-    0,    6,    0,    0,   10,    1,    0,    5,    1,    3,
-    4,    4,    0,    3,    3,    3,    3,    3,    3,    1,
-    2,    2,    3,    3,    1,    3,    3,    1,    1,    3,
-    1,    1,    3,    1,    3,
+    0,    3,    3,    1,    1,    1,    1,    1,    1,    1,
+    1,    1,    1,    3,    0,    0,    7,    0,    0,    3,
+    0,    0,    6,    0,    0,   10,    1,    0,    5,    1,
+    3,    4,    4,    0,    3,    3,    3,    3,    3,    3,
+    1,    2,    2,    3,    3,    1,    3,    3,    1,    1,
+    3,    1,    1,    3,    1,    3,
 };
 static const short yydefred[] = {                         0,
     0,    0,    0,    0,    8,    0,    0,    0,    7,    0,
-    1,    0,    2,    0,   13,   14,    0,   74,    0,   20,
+    1,    0,    2,    0,   13,   14,    0,   75,    0,   20,
     0,    0,    0,    6,    0,   15,    0,    0,    0,    0,
-    0,   40,    0,    0,    0,    3,   24,   25,   26,   27,
-   28,   29,   30,   31,   32,   12,   75,    0,    0,   23,
-    0,    0,    0,    0,    0,   69,   71,    0,    0,    0,
-   65,   68,    0,    0,    0,    0,    0,    0,   16,    0,
-   50,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-    0,    0,    0,    0,   34,    0,    0,    0,    0,    0,
-    0,    0,    0,   21,    0,   22,    0,   70,    0,    0,
-    0,    0,    0,    0,    0,    0,    0,   66,   67,   51,
-   41,   52,    0,    0,   18,    0,   35,    0,    0,   48,
-    0,    0,    0,   42,   19,    0,   38,   36,    0,    0,
-    0,   39,   45,
+    0,   41,    0,    0,    0,    3,   25,   26,   27,   28,
+   29,   30,   31,   32,   33,   12,   76,    0,    0,   24,
+    0,    0,    0,    0,    0,   70,   72,    0,    0,    0,
+   66,   69,    0,    0,    0,    0,    0,   21,   16,    0,
+   51,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,   35,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,    0,   23,    0,   71,    0,    0,
+    0,    0,    0,    0,    0,    0,    0,   67,   68,   52,
+   42,   53,    0,    0,   22,   18,    0,   36,    0,    0,
+   49,    0,    0,    0,   43,   19,    0,   39,   37,    0,
+    0,    0,   40,   46,
 };
 static const short yydgoto[] = {                          2,
    21,   35,    6,   68,   13,   36,   22,    8,    9,   19,
-   10,   14,   15,   16,   69,   48,   27,  121,   51,   37,
-   38,   39,   40,   41,   42,   43,   44,   45,   58,   59,
-  107,  128,  123,  130,   64,  118,  116,  129,   93,  114,
-   60,   61,   62,
+   10,   14,   15,   16,   69,   48,   27,  122,   94,   51,
+   37,   38,   39,   40,   41,   42,   43,   44,   45,   58,
+   59,  107,  129,  124,  131,   64,  119,  117,  130,   93,
+  114,   60,   61,   62,
 };
-static const short yysindex[] = {                      -229,
- -272,    0, -240, -199,    0, -233, -187, -206,    0, -196,
-    0, -181,    0, -173,    0,    0, -199,    0, -159,    0,
- -151, -153, -187,    0, -154,    0, -148, -153, -146, -119,
- -114,    0, -113, -121,  -99,    0,    0,    0,    0,    0,
-    0,    0,    0,    0,    0,    0,    0, -199, -196,    0,
- -256, -110, -278, -278, -119,    0,    0,   17,  -83, -155,
-    0,    0, -106, -119, -119, -119, -119, -153,    0, -266,
-    0, -153, -119, -155, -155, -267, -278, -278, -119, -119,
- -119, -119, -119, -119,    0, -278, -278,  -95,  -63, -221,
- -123, -123,  -91,    0,  -90,    0, -123,    0, -155, -155,
- -123, -123, -123, -123, -123, -123, -153,    0,    0,    0,
-    0,    0, -119,  -85,    0,  -69,    0, -153, -123,    0,
- -199, -119,  -56,    0,    0, -123,    0,    0,  -53, -153,
- -153,    0,    0,
+static const short yysindex[] = {                      -256,
+ -270,    0, -240, -209,    0, -219, -189, -199,    0, -198,
+    0, -176,    0, -149,    0,    0, -209,    0, -147,    0,
+ -136, -150, -189,    0, -135,    0, -193, -150, -129, -119,
+ -125,    0, -115, -114, -110,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,    0,    0,    0, -209, -198,    0,
+ -254, -113, -276, -276, -119,    0,    0,   21,  -82, -273,
+    0,    0, -106, -119, -119, -119, -119,    0,    0, -151,
+    0, -150, -119, -273, -273, -154, -276, -276, -119, -119,
+ -119, -119, -119, -119,    0, -276, -276,  -95,  -66, -139,
+ -258, -258,  -94, -150,  -90,    0, -258,    0, -273, -273,
+ -258, -258, -258, -258, -258, -258, -150,    0,    0,    0,
+    0,    0, -119,  -85,    0,    0,  -69,    0, -150, -258,
+    0, -209, -119,  -58,    0,    0, -258,    0,    0,  -56,
+ -150, -150,    0,    0,
 };
 static const short yyrindex[] = {                         0,
-    0,    0,    0, -210,    0,    0, -197,    0,    0,    0,
-    0,    0,    0,    0,    0,    0, -222,    0,  -84,    0,
-  -75,  -82, -184,    0,    0,    0,    0, -252,    0,    0,
-    0,    0,    0, -250, -257,    0,    0,    0,    0,    0,
-    0,    0,    0,    0,    0,    0,    0, -172,    0,    0,
-    0,    0,    0,    0,    0,    0,    0,    0,    0, -135,
-    0,    0,    0,    0,    0,    0,    0,  -72,    0,    0,
-    0, -252,    0, -101,  -67,    0,    0,    0,    0,    0,
+    0,    0,    0, -214,    0,    0, -197,    0,    0,    0,
+    0,    0,    0,    0,    0,    0, -226,    0,  -84,    0,
+  -80,  -83, -179,    0,    0,    0,    0, -246,    0,    0,
+    0,    0,    0, -251, -255,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,    0,    0,    0, -162,    0,    0,
+    0,    0,    0,    0,    0,    0,    0,    0,    0, -131,
     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
- -128, -264,  -66,    0,    0,    0,  -50,    0,  -33,    1,
- -244, -212, -182, -167, -141, -132,  -94,    0,    0,    0,
-    0,    0,    0,    0,    0,    0,    0,  -94, -175,    0,
- -172,    0, -195,    0,    0,  -36,    0,    0,    0,  -94,
-  -94,    0,    0,
+    0, -246,    0,  -97,  -63,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+ -239, -118,  -77,  -79,    0,    0,  -57,    0,  -29,    5,
+ -195, -187, -160, -152, -145, -127, -205,    0,    0,    0,
+    0,    0,    0,    0,    0,    0,    0,    0, -205, -117,
+    0, -162,    0, -204,    0,    0,  -45,    0,    0,    0,
+ -205, -205,    0,    0,
 };
 static const short yygindex[] = {                         0,
-    0,    0,    0,  219,    0,  -28,    0,    0,  211,  180,
-    0,    0,  207,    0,  110,    0,    0,    0,    0,    0,
-    0,    0,    0,    0,    0,    0,    0,    0,  -54,  168,
-    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-   52,   75,    0,
+    0,    0,    0,  216,    0,  -28,    0,    0,  205,  174,
+    0,    0,  203,    0,  105,    0,    0,    0,    0,    0,
+    0,    0,    0,    0,    0,    0,    0,    0,    0,  -54,
+  168,    0,    0,    0,    0,    0,    0,    0,    0,    0,
+    0,   47,  -64,    0,
 };
-#define YYTABLESIZE 299
+#define YYTABLESIZE 303
 static const short yytable[] = {                         50,
-   76,   46,   46,   71,   55,   77,   78,   53,   49,   49,
-   90,   91,   92,   54,   56,   57,   98,   95,   97,   72,
-   25,    3,   72,   54,  101,  102,  103,  104,  105,  106,
-   46,   72,   49,   46,    5,   53,    1,   49,    5,   94,
-   49,    5,    5,   96,    5,   55,    4,    4,    5,    5,
-    4,   77,   78,    4,    4,   55,    4,   11,  119,   10,
-    4,    4,  112,   10,   37,    5,   10,  126,    5,   10,
-    5,    5,   11,   10,   10,   57,   11,   12,  117,   11,
-    4,   17,   11,    4,    4,   57,   11,   11,    4,  124,
-   56,    4,   37,   10,    4,   37,   10,   18,    4,    4,
-   56,  132,  133,   28,   74,   75,   11,   29,   73,   11,
-   30,   73,   20,   31,   23,    4,   59,   32,   33,   86,
-   87,    4,   60,   60,   60,   58,   59,   25,   99,  100,
-   33,   33,   60,   60,   49,   58,   26,   60,   60,   47,
-   34,   60,   60,   60,   60,   60,   60,   52,   60,   77,
-   78,   60,   60,   53,   54,   60,   61,   61,   61,   33,
-  108,  109,   33,   55,   53,   53,   61,   61,   63,   65,
-   66,   61,   61,   56,   57,   61,   61,   61,   61,   61,
-   61,   73,   61,   67,   85,   61,   61,   88,  110,   61,
-   62,   62,   62,   53,  111,  113,   53,  115,  120,  122,
-   62,   62,  127,    9,  131,   62,   62,   17,   53,   62,
-   62,   62,   62,   62,   62,   53,   62,   47,   43,   62,
-   62,   44,    7,   62,   63,   63,   63,   24,   70,   46,
-  125,   89,    0,    0,   63,   63,    0,    0,    0,   63,
-   63,    0,    0,   63,   63,   63,   63,   63,   63,    0,
-   63,    0,    0,   63,   63,    0,    0,   63,   64,   64,
-   64,    0,    0,    0,    0,    0,    0,    0,   64,   64,
+   76,   86,   87,   47,   47,   71,   55,   50,   50,    1,
+   90,   91,   92,   54,   77,   78,   56,   57,   97,   34,
+   34,  108,  109,    3,  101,  102,  103,  104,  105,  106,
+    5,   50,   47,   72,    5,   47,   50,    5,    5,   50,
+    5,   54,    4,   96,    5,    5,    4,    4,   34,    4,
+    4,   34,    4,   54,   54,   38,    4,    4,  120,   10,
+    5,    5,   55,   10,    5,  115,   10,    5,  127,   10,
+   56,   11,   55,   10,   10,   12,    4,   11,  118,    4,
+   56,   11,   54,   38,   11,   54,   38,   11,   17,   49,
+  125,   11,   11,   10,    4,   18,   10,   58,    4,   74,
+   75,    4,  133,  134,    4,   57,   28,   58,    4,    4,
+   29,   11,   60,   30,   11,   57,   31,   20,   77,   78,
+   32,   33,   60,   99,  100,    4,   61,   61,   61,   98,
+   59,    4,   95,   77,   78,   25,   61,   61,   23,   25,
+   59,   61,   61,   34,  112,   61,   61,   61,   61,   61,
+   61,   26,   61,   53,   54,   61,   61,   63,   47,   61,
+   62,   62,   62,   55,   52,   73,   74,   65,   73,   74,
+   62,   62,   67,   56,   57,   62,   62,   66,   73,   62,
+   62,   62,   62,   62,   62,   85,   62,   88,  110,   62,
+   62,  111,  113,   62,   63,   63,   63,  116,  121,  123,
+  128,  132,   17,    9,   63,   63,   48,   54,   54,   63,
+   63,   44,   45,   63,   63,   63,   63,   63,   63,    7,
+   63,   24,   70,   63,   63,   46,  126,   63,   64,   64,
+   64,   89,    0,    0,    0,    0,    0,    0,   64,   64,
     0,    0,    0,   64,   64,    0,    0,   64,   64,   64,
-   64,   64,   64,    0,   64,    0,    0,   64,   64,   77,
-   78,   64,    0,   79,   80,   81,   82,   83,   84,
+   64,   64,   64,    0,   64,    0,    0,   64,   64,    0,
+    0,   64,   65,   65,   65,    0,    0,    0,    0,    0,
+    0,    0,   65,   65,    0,    0,    0,   65,   65,    0,
+    0,   65,   65,   65,   65,   65,   65,    0,   65,    0,
+    0,   65,   65,   77,   78,   65,    0,   79,   80,   81,
+   82,   83,   84,
 };
 static const short yycheck[] = {                         28,
-   55,  259,  260,  260,  283,  273,  274,  260,  259,  260,
-   65,   66,   67,  258,  293,  294,  284,  284,   73,  284,
-  287,  294,  287,  268,   79,   80,   81,   82,   83,   84,
-  288,  288,  283,  291,  257,  288,  266,  288,  261,   68,
-  291,  264,  265,   72,  267,  258,  257,  288,  271,  272,
-  261,  273,  274,  264,  265,  268,  267,  291,  113,  257,
-  271,  272,  284,  261,  260,  288,  264,  122,  291,  267,
-  270,  294,  257,  271,  272,  258,  261,  265,  107,  264,
-  291,  288,  267,  294,  257,  268,  271,  272,  261,  118,
-  258,  264,  288,  291,  267,  291,  294,  294,  271,  272,
-  268,  130,  131,  257,   53,   54,  291,  261,  284,  294,
-  264,  287,  294,  267,  288,  288,  258,  271,  272,  275,
-  276,  294,  258,  259,  260,  258,  268,  287,   77,   78,
-  259,  260,  268,  269,  283,  268,  288,  273,  274,  294,
-  294,  277,  278,  279,  280,  281,  282,  294,  284,  273,
-  274,  287,  288,  273,  274,  291,  258,  259,  260,  288,
-   86,   87,  291,  283,  259,  260,  268,  269,  283,  283,
-  292,  273,  274,  293,  294,  277,  278,  279,  280,  281,
-  282,  292,  284,  283,  268,  287,  288,  294,  284,  291,
-  258,  259,  260,  288,  258,  287,  291,  288,  284,  269,
-  268,  269,  259,  288,  258,  273,  274,  283,  291,  277,
-  278,  279,  280,  281,  282,  288,  284,  284,  269,  287,
-  288,  258,    4,  291,  258,  259,  260,   17,   49,   23,
-  121,   64,   -1,   -1,  268,  269,   -1,   -1,   -1,  273,
-  274,   -1,   -1,  277,  278,  279,  280,  281,  282,   -1,
-  284,   -1,   -1,  287,  288,   -1,   -1,  291,  258,  259,
-  260,   -1,   -1,   -1,   -1,   -1,   -1,   -1,  268,  269,
+   55,  275,  276,  259,  260,  260,  283,  259,  260,  266,
+   65,   66,   67,  260,  273,  274,  293,  294,   73,  259,
+  260,   86,   87,  294,   79,   80,   81,   82,   83,   84,
+  257,  283,  288,  288,  261,  291,  288,  264,  265,  291,
+  267,  288,  257,   72,  271,  272,  261,  288,  288,  264,
+  265,  291,  267,  259,  260,  260,  271,  272,  113,  257,
+  270,  288,  258,  261,  291,   94,  264,  294,  123,  267,
+  258,  291,  268,  271,  272,  265,  291,  257,  107,  294,
+  268,  261,  288,  288,  264,  291,  291,  267,  288,  283,
+  119,  271,  272,  291,  257,  294,  294,  258,  261,   53,
+   54,  264,  131,  132,  267,  258,  257,  268,  271,  272,
+  261,  291,  258,  264,  294,  268,  267,  294,  273,  274,
+  271,  272,  268,   77,   78,  288,  258,  259,  260,  284,
+  258,  294,  284,  273,  274,  287,  268,  269,  288,  287,
+  268,  273,  274,  294,  284,  277,  278,  279,  280,  281,
+  282,  288,  284,  273,  274,  287,  288,  283,  294,  291,
+  258,  259,  260,  283,  294,  284,  284,  283,  287,  287,
+  268,  269,  283,  293,  294,  273,  274,  292,  292,  277,
+  278,  279,  280,  281,  282,  268,  284,  294,  284,  287,
+  288,  258,  287,  291,  258,  259,  260,  288,  284,  269,
+  259,  258,  283,  288,  268,  269,  284,  291,  288,  273,
+  274,  269,  258,  277,  278,  279,  280,  281,  282,    4,
+  284,   17,   49,  287,  288,   23,  122,  291,  258,  259,
+  260,   64,   -1,   -1,   -1,   -1,   -1,   -1,  268,  269,
    -1,   -1,   -1,  273,  274,   -1,   -1,  277,  278,  279,
-  280,  281,  282,   -1,  284,   -1,   -1,  287,  288,  273,
-  274,  291,   -1,  277,  278,  279,  280,  281,  282,
+  280,  281,  282,   -1,  284,   -1,   -1,  287,  288,   -1,
+   -1,  291,  258,  259,  260,   -1,   -1,   -1,   -1,   -1,
+   -1,   -1,  268,  269,   -1,   -1,   -1,  273,  274,   -1,
+   -1,  277,  278,  279,  280,  281,  282,   -1,  284,   -1,
+   -1,  287,  288,  273,  274,  291,   -1,  277,  278,  279,
+  280,  281,  282,
 };
 #define YYFINAL 2
 #ifndef YYDEBUG
@@ -320,7 +357,8 @@ static const char *yyrule[] = {
 "$$5 :",
 "proc_decl : PROCEDURE proc_name $$4 LPAREN id_list RPAREN SEMICOLON $$5 inblock",
 "proc_name : IDENT",
-"inblock : var_decl_part statement",
+"$$6 :",
+"inblock : var_decl_part $$6 statement",
 "statement_list : statement_list SEMICOLON statement",
 "statement_list : statement",
 "statement : assignment_statement",
@@ -333,21 +371,21 @@ static const char *yyrule[] = {
 "statement : read_statement",
 "statement : write_statement",
 "assignment_statement : IDENT ASSIGN expression",
-"$$6 :",
 "$$7 :",
-"if_statement : IF condition THEN $$6 statement $$7 else_statement",
-"else_statement :",
 "$$8 :",
-"else_statement : ELSE $$8 statement",
+"if_statement : IF condition THEN $$7 statement $$8 else_statement",
+"else_statement :",
 "$$9 :",
+"else_statement : ELSE $$9 statement",
 "$$10 :",
-"while_statement : WHILE $$9 condition DO $$10 statement",
 "$$11 :",
+"while_statement : WHILE $$10 condition DO $$11 statement",
 "$$12 :",
-"for_statement : FOR IDENT ASSIGN expression $$11 TO expression $$12 DO statement",
-"proc_call_statement : proc_call_name",
 "$$13 :",
-"proc_call_statement : proc_call_name LPAREN arg_list $$13 RPAREN",
+"for_statement : FOR IDENT ASSIGN expression $$12 TO expression $$13 DO statement",
+"proc_call_statement : proc_call_name",
+"$$14 :",
+"proc_call_statement : proc_call_name LPAREN arg_list $$14 RPAREN",
 "proc_call_name : IDENT",
 "block_statement : SBEGIN statement_list SEND",
 "read_statement : READ LPAREN IDENT RPAREN",
@@ -412,7 +450,7 @@ typedef struct {
 } YYSTACKDATA;
 /* variables for the parser stack */
 static YYSTACKDATA yystack;
-#line 403 "parser.y"
+#line 454 "parser.y"
 
 
 yyerror(char *s)
@@ -426,7 +464,7 @@ yyerror(char *s)
                 s, yylineno, yytext
         );
 }
-#line 429 "y.tab.c"
+#line 467 "y.tab.c"
 
 #if YYDEBUG
 #include <stdio.h>		/* needed for printf */
@@ -633,16 +671,15 @@ yyreduce:
     switch (yyn)
     {
 case 1:
-#line 61 "parser.y"
+#line 96 "parser.y"
 	{
         if ((fp = fopen(filename, "w")) == NULL) return EXIT_FAILURE;
         display_llvm();
         fclose(fp);
-        /*debug_symbol_table();*/
         }
 break;
 case 2:
-#line 70 "parser.y"
+#line 104 "parser.y"
 	{
         insert_decl("main", 0, NULL);
         Factor x = {CONSTANT, "1", 0};
@@ -654,7 +691,7 @@ case 2:
         }
 break;
 case 3:
-#line 79 "parser.y"
+#line 113 "parser.y"
 	{
         back_patch();
         /*insert_code(Load);*/
@@ -662,115 +699,126 @@ case 3:
         }
 break;
 case 8:
-#line 97 "parser.y"
+#line 131 "parser.y"
 	{
         var_mode = TRUE;
         }
 break;
 case 9:
-#line 99 "parser.y"
+#line 133 "parser.y"
 	{
         var_mode = FALSE;
-        /*VARの時はただちに記号表を正しい値に書き換える*/
-        /*引数の時はAllocaとかをしてから書き換えないといけない*/
-        overwrite_symbol_val(count);
         }
 break;
 case 15:
-#line 122 "parser.y"
+#line 153 "parser.y"
 	{
         scope = LOCAL_VAR;
         count = 0;
         insert_symbol(PROC_NAME, yystack.l_mark[-1].ident, 0);
         insert_decl(yystack.l_mark[-1].ident, 0, NULL);
         reg_counter = count + 1;
-        insert_code(Alloca);
-        overwrite_symbol_val(count + 1);
+        count++;
         }
 break;
 case 16:
-#line 131 "parser.y"
+#line 161 "parser.y"
 	{
         back_patch();
-        /*debug_symbol_table();*/
         delete_local_symbol();
         scope = GLOBAL_VAR;
         }
 break;
 case 17:
-#line 138 "parser.y"
+#line 167 "parser.y"
 	{
         scope = LOCAL_VAR;
         count = 0;
         insert_symbol(PROC_NAME, yystack.l_mark[0].ident, count);
-        var_mode = TRUE;
+        arity_mode = TRUE;
         }
 break;
 case 18:
-#line 143 "parser.y"
+#line 172 "parser.y"
 	{
-                var_mode = FALSE;
+                arity_mode = FALSE;
                 /*レジスタの値は返り値分一つ増やしておく*/
-                /*count: 引数の個数*/
-                /*reg_counter: 引数(n個),返り値(1個),中身(m個)の順に番号づけされる*/
-                reg_counter = count + 1;
+                /*reg_counter: 引数(n個),返り値(1個),局所変数(m個), 中身(k個)の順に番号づけされる*/
                 insert_decl(yystack.l_mark[-5].ident, count, NULL);
-                for (i = 0; i < count; i++) {
-                        insert_code(Alloca);
-                }
-                for (i = 0; i < count; i++) {
-                        insert_code(Store);
-                }
-                /*記号表のアドレスの更新,新しいlocal varを突っ込む,引数は全てlocalだから上書きオッケー*/
-                overwrite_symbol_val(count + 1);
+                reg_counter = count + 1;
+                count++;
         }
 break;
 case 19:
-#line 159 "parser.y"
+#line 180 "parser.y"
 	{
         back_patch();
-        /*debug_symbol_table();*/
         delete_local_symbol();
         scope = GLOBAL_VAR;
         }
 break;
-case 33:
-#line 196 "parser.y"
+case 21:
+#line 195 "parser.y"
+	{
+                for (i = 0; i < var_num + arity_num; i++) {
+                        tmp1_element[i] = factor_pop();
+                        tmp1_top++;
+                }
+                for (i = 0; i < var_num + arity_num; i++) {
+                        insert_code(Alloca);
+                }
+                for (i = 0; i < var_num + arity_num; i++) {
+                        tmp2_element[i] = factor_pop();
+                        tmp2_top++;
+                }
+                for (i = var_num + arity_num ; i > var_num; i--) {
+                        factor_push(tmp1_element[i-1]);
+                        factor_push(tmp2_element[i-1]);
+                        insert_code(Store);
+                }
+                tmp1_top = 0;
+                tmp2_top = 0;
+                /*記号表のアドレスの更新,新しいlocal varを突っ込む,引数は全てlocalだから上書きオッケー*/
+                overwrite_symbol_val(var_num, arity_num);
+        }
+break;
+case 34:
+#line 237 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
         insert_code(Store);
         }
 break;
-case 34:
-#line 204 "parser.y"
+case 35:
+#line 245 "parser.y"
 	{
         insert_code(BrCond);
         insert_code(Label);
         }
 break;
-case 35:
-#line 208 "parser.y"
+case 36:
+#line 249 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
         }
 break;
-case 37:
-#line 216 "parser.y"
+case 38:
+#line 257 "parser.y"
 	{
         label_push(reg_counter);
-        insert_code(Label);
-        }
-break;
-case 38:
-#line 220 "parser.y"
-	{
         insert_code(Label);
         }
 break;
 case 39:
-#line 223 "parser.y"
+#line 261 "parser.y"
+	{
+        insert_code(Label);
+        }
+break;
+case 40:
+#line 264 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -778,8 +826,8 @@ case 39:
         insert_code(Label);
         }
 break;
-case 40:
-#line 232 "parser.y"
+case 41:
+#line 273 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -787,15 +835,15 @@ case 40:
         insert_code(Label);
         }
 break;
-case 41:
-#line 238 "parser.y"
+case 42:
+#line 279 "parser.y"
 	{
         insert_code(BrCond);
         insert_code(Label);
         }
 break;
-case 42:
-#line 242 "parser.y"
+case 43:
+#line 283 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -803,8 +851,8 @@ case 42:
         insert_code(Label);
         }
 break;
-case 43:
-#line 251 "parser.y"
+case 44:
+#line 292 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
@@ -817,8 +865,8 @@ case 43:
         insert_code(Load);
         }
 break;
-case 44:
-#line 262 "parser.y"
+case 45:
+#line 303 "parser.y"
 	{
         set_cmp_type(SLE);
         insert_code(Icmp);
@@ -826,8 +874,8 @@ case 44:
         insert_code(Label);
         }
 break;
-case 45:
-#line 268 "parser.y"
+case 46:
+#line 309 "parser.y"
 	{
         insert_code(BrUncond);
         tmp2 = reg_counter;
@@ -848,24 +896,24 @@ case 45:
         insert_code(Label);
         }
 break;
-case 46:
-#line 290 "parser.y"
+case 47:
+#line 331 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[0].ident);
         factor_push(x);
         insert_code(Proc);
         }
 break;
-case 47:
-#line 295 "parser.y"
+case 48:
+#line 336 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
         insert_code(Proc);
         }
 break;
-case 51:
-#line 311 "parser.y"
+case 52:
+#line 352 "parser.y"
 	{
         set_read_flag(TRUE);
         Factor x = create_factor_by_name(yystack.l_mark[-1].ident);
@@ -873,62 +921,62 @@ case 51:
         insert_code(Read);
         }
 break;
-case 52:
-#line 320 "parser.y"
+case 53:
+#line 361 "parser.y"
 	{
         set_write_flag(TRUE);
         insert_code(Write);
         }
 break;
-case 54:
-#line 331 "parser.y"
+case 55:
+#line 372 "parser.y"
 	{set_cmp_type(EQUAL); insert_code(Icmp);}
 break;
-case 55:
-#line 332 "parser.y"
+case 56:
+#line 373 "parser.y"
 	{set_cmp_type(NE); insert_code(Icmp);}
 break;
-case 56:
-#line 333 "parser.y"
+case 57:
+#line 374 "parser.y"
 	{set_cmp_type(SLT); insert_code(Icmp);}
 break;
-case 57:
-#line 334 "parser.y"
+case 58:
+#line 375 "parser.y"
 	{set_cmp_type(SLE); insert_code(Icmp);}
 break;
-case 58:
-#line 335 "parser.y"
+case 59:
+#line 376 "parser.y"
 	{set_cmp_type(SGT); insert_code(Icmp);}
 break;
-case 59:
-#line 336 "parser.y"
+case 60:
+#line 377 "parser.y"
 	{set_cmp_type(SGE); insert_code(Icmp);}
 break;
-case 63:
-#line 343 "parser.y"
+case 64:
+#line 384 "parser.y"
 	{insert_code(Add);}
 break;
-case 64:
-#line 344 "parser.y"
+case 65:
+#line 385 "parser.y"
 	{insert_code(Sub);}
 break;
-case 66:
-#line 349 "parser.y"
+case 67:
+#line 390 "parser.y"
 	{insert_code(Mult);}
 break;
-case 67:
-#line 350 "parser.y"
+case 68:
+#line 391 "parser.y"
 	{insert_code(Div);}
 break;
-case 69:
-#line 355 "parser.y"
+case 70:
+#line 396 "parser.y"
 	{
         Factor x = {CONSTANT, "", yystack.l_mark[0].num};
         factor_push(x);
         }
 break;
-case 71:
-#line 363 "parser.y"
+case 72:
+#line 404 "parser.y"
 	{
         /*ここの記号表に各処理をいじらないとだめそう*/
         /*記号表のvalの値を書き換えていく*/
@@ -937,16 +985,8 @@ case 71:
         insert_code(Load);
         }
 break;
-case 72:
-#line 373 "parser.y"
-	{
-        Factor x = factor_pop();
-        arity_push(x);
-        factor_push(x);
-        }
-break;
 case 73:
-#line 378 "parser.y"
+#line 414 "parser.y"
 	{
         Factor x = factor_pop();
         arity_push(x);
@@ -954,26 +994,44 @@ case 73:
         }
 break;
 case 74:
-#line 386 "parser.y"
+#line 419 "parser.y"
 	{
-        if (var_mode) {
-                insert_symbol(scope, yystack.l_mark[0].ident, count++);
-        }
-        Factor x = create_factor_by_name(yystack.l_mark[0].ident);
+        Factor x = factor_pop();
+        arity_push(x);
         factor_push(x);
         }
 break;
 case 75:
-#line 393 "parser.y"
+#line 427 "parser.y"
 	{
         if (var_mode) {
+                if (scope == LOCAL_VAR) var_num++;
+                insert_symbol(scope, yystack.l_mark[0].ident, count++);
+        }
+        if (arity_mode) {
+                arity_num++;
                 insert_symbol(scope, yystack.l_mark[0].ident, count++);
         }
         Factor x = create_factor_by_name(yystack.l_mark[0].ident);
         factor_push(x);
         }
 break;
-#line 976 "y.tab.c"
+case 76:
+#line 439 "parser.y"
+	{
+        if (var_mode) {
+                if (scope == LOCAL_VAR) var_num++;
+                insert_symbol(scope, yystack.l_mark[0].ident, count++);
+        }
+        if (arity_mode) {
+                arity_num++;
+                insert_symbol(scope, yystack.l_mark[0].ident, count++);
+        }
+        Factor x = create_factor_by_name(yystack.l_mark[0].ident);
+        factor_push(x);
+        }
+break;
+#line 1034 "y.tab.c"
     }
     yystack.s_mark -= yym;
     yystate = *yystack.s_mark;

--- a/y.tab.c
+++ b/y.tab.c
@@ -450,7 +450,7 @@ typedef struct {
 } YYSTACKDATA;
 /* variables for the parser stack */
 static YYSTACKDATA yystack;
-#line 454 "parser.y"
+#line 456 "parser.y"
 
 
 yyerror(char *s)
@@ -715,6 +715,8 @@ case 15:
 	{
         scope = LOCAL_VAR;
         count = 0;
+        var_num = 0;
+        arity_num = 0;
         insert_symbol(PROC_NAME, yystack.l_mark[-1].ident, 0);
         insert_decl(yystack.l_mark[-1].ident, 0, NULL);
         reg_counter = count + 1;
@@ -722,7 +724,7 @@ case 15:
         }
 break;
 case 16:
-#line 161 "parser.y"
+#line 163 "parser.y"
 	{
         back_patch();
         delete_local_symbol();
@@ -730,7 +732,7 @@ case 16:
         }
 break;
 case 17:
-#line 167 "parser.y"
+#line 169 "parser.y"
 	{
         scope = LOCAL_VAR;
         count = 0;
@@ -739,7 +741,7 @@ case 17:
         }
 break;
 case 18:
-#line 172 "parser.y"
+#line 174 "parser.y"
 	{
                 arity_mode = FALSE;
                 /*レジスタの値は返り値分一つ増やしておく*/
@@ -750,7 +752,7 @@ case 18:
         }
 break;
 case 19:
-#line 180 "parser.y"
+#line 182 "parser.y"
 	{
         back_patch();
         delete_local_symbol();
@@ -758,7 +760,7 @@ case 19:
         }
 break;
 case 21:
-#line 195 "parser.y"
+#line 197 "parser.y"
 	{
                 for (i = 0; i < var_num + arity_num; i++) {
                         tmp1_element[i] = factor_pop();
@@ -783,7 +785,7 @@ case 21:
         }
 break;
 case 34:
-#line 237 "parser.y"
+#line 239 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
@@ -791,34 +793,34 @@ case 34:
         }
 break;
 case 35:
-#line 245 "parser.y"
+#line 247 "parser.y"
 	{
         insert_code(BrCond);
         insert_code(Label);
         }
 break;
 case 36:
-#line 249 "parser.y"
+#line 251 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
         }
 break;
 case 38:
-#line 257 "parser.y"
+#line 259 "parser.y"
 	{
         label_push(reg_counter);
         insert_code(Label);
         }
 break;
 case 39:
-#line 261 "parser.y"
+#line 263 "parser.y"
 	{
         insert_code(Label);
         }
 break;
 case 40:
-#line 264 "parser.y"
+#line 266 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -827,7 +829,7 @@ case 40:
         }
 break;
 case 41:
-#line 273 "parser.y"
+#line 275 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -836,14 +838,14 @@ case 41:
         }
 break;
 case 42:
-#line 279 "parser.y"
+#line 281 "parser.y"
 	{
         insert_code(BrCond);
         insert_code(Label);
         }
 break;
 case 43:
-#line 283 "parser.y"
+#line 285 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -852,7 +854,7 @@ case 43:
         }
 break;
 case 44:
-#line 292 "parser.y"
+#line 294 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
@@ -866,7 +868,7 @@ case 44:
         }
 break;
 case 45:
-#line 303 "parser.y"
+#line 305 "parser.y"
 	{
         set_cmp_type(SLE);
         insert_code(Icmp);
@@ -875,7 +877,7 @@ case 45:
         }
 break;
 case 46:
-#line 309 "parser.y"
+#line 311 "parser.y"
 	{
         insert_code(BrUncond);
         tmp2 = reg_counter;
@@ -897,7 +899,7 @@ case 46:
         }
 break;
 case 47:
-#line 331 "parser.y"
+#line 333 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[0].ident);
         factor_push(x);
@@ -905,7 +907,7 @@ case 47:
         }
 break;
 case 48:
-#line 336 "parser.y"
+#line 338 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
@@ -913,7 +915,7 @@ case 48:
         }
 break;
 case 52:
-#line 352 "parser.y"
+#line 354 "parser.y"
 	{
         set_read_flag(TRUE);
         Factor x = create_factor_by_name(yystack.l_mark[-1].ident);
@@ -922,61 +924,61 @@ case 52:
         }
 break;
 case 53:
-#line 361 "parser.y"
+#line 363 "parser.y"
 	{
         set_write_flag(TRUE);
         insert_code(Write);
         }
 break;
 case 55:
-#line 372 "parser.y"
+#line 374 "parser.y"
 	{set_cmp_type(EQUAL); insert_code(Icmp);}
 break;
 case 56:
-#line 373 "parser.y"
+#line 375 "parser.y"
 	{set_cmp_type(NE); insert_code(Icmp);}
 break;
 case 57:
-#line 374 "parser.y"
+#line 376 "parser.y"
 	{set_cmp_type(SLT); insert_code(Icmp);}
 break;
 case 58:
-#line 375 "parser.y"
+#line 377 "parser.y"
 	{set_cmp_type(SLE); insert_code(Icmp);}
 break;
 case 59:
-#line 376 "parser.y"
+#line 378 "parser.y"
 	{set_cmp_type(SGT); insert_code(Icmp);}
 break;
 case 60:
-#line 377 "parser.y"
+#line 379 "parser.y"
 	{set_cmp_type(SGE); insert_code(Icmp);}
 break;
 case 64:
-#line 384 "parser.y"
+#line 386 "parser.y"
 	{insert_code(Add);}
 break;
 case 65:
-#line 385 "parser.y"
+#line 387 "parser.y"
 	{insert_code(Sub);}
 break;
 case 67:
-#line 390 "parser.y"
+#line 392 "parser.y"
 	{insert_code(Mult);}
 break;
 case 68:
-#line 391 "parser.y"
+#line 393 "parser.y"
 	{insert_code(Div);}
 break;
 case 70:
-#line 396 "parser.y"
+#line 398 "parser.y"
 	{
         Factor x = {CONSTANT, "", yystack.l_mark[0].num};
         factor_push(x);
         }
 break;
 case 72:
-#line 404 "parser.y"
+#line 406 "parser.y"
 	{
         /*ここの記号表に各処理をいじらないとだめそう*/
         /*記号表のvalの値を書き換えていく*/
@@ -986,7 +988,7 @@ case 72:
         }
 break;
 case 73:
-#line 414 "parser.y"
+#line 416 "parser.y"
 	{
         Factor x = factor_pop();
         arity_push(x);
@@ -994,7 +996,7 @@ case 73:
         }
 break;
 case 74:
-#line 419 "parser.y"
+#line 421 "parser.y"
 	{
         Factor x = factor_pop();
         arity_push(x);
@@ -1002,7 +1004,7 @@ case 74:
         }
 break;
 case 75:
-#line 427 "parser.y"
+#line 429 "parser.y"
 	{
         if (var_mode) {
                 if (scope == LOCAL_VAR) var_num++;
@@ -1017,7 +1019,7 @@ case 75:
         }
 break;
 case 76:
-#line 439 "parser.y"
+#line 441 "parser.y"
 	{
         if (var_mode) {
                 if (scope == LOCAL_VAR) var_num++;
@@ -1031,7 +1033,7 @@ case 76:
         factor_push(x);
         }
 break;
-#line 1034 "y.tab.c"
+#line 1036 "y.tab.c"
     }
     yystack.s_mark -= yym;
     yystate = *yystack.s_mark;

--- a/y.tab.c
+++ b/y.tab.c
@@ -412,7 +412,7 @@ typedef struct {
 } YYSTACKDATA;
 /* variables for the parser stack */
 static YYSTACKDATA yystack;
-#line 400 "parser.y"
+#line 403 "parser.y"
 
 
 yyerror(char *s)
@@ -735,7 +735,7 @@ case 19:
         }
 break;
 case 33:
-#line 193 "parser.y"
+#line 196 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
@@ -743,34 +743,34 @@ case 33:
         }
 break;
 case 34:
-#line 201 "parser.y"
+#line 204 "parser.y"
 	{
         insert_code(BrCond);
         insert_code(Label);
         }
 break;
 case 35:
-#line 205 "parser.y"
+#line 208 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
         }
 break;
 case 37:
-#line 213 "parser.y"
+#line 216 "parser.y"
 	{
         label_push(reg_counter);
         insert_code(Label);
         }
 break;
 case 38:
-#line 217 "parser.y"
+#line 220 "parser.y"
 	{
         insert_code(Label);
         }
 break;
 case 39:
-#line 220 "parser.y"
+#line 223 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -779,7 +779,7 @@ case 39:
         }
 break;
 case 40:
-#line 229 "parser.y"
+#line 232 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -788,14 +788,14 @@ case 40:
         }
 break;
 case 41:
-#line 235 "parser.y"
+#line 238 "parser.y"
 	{
         insert_code(BrCond);
         insert_code(Label);
         }
 break;
 case 42:
-#line 239 "parser.y"
+#line 242 "parser.y"
 	{
         insert_code(BrUncond);
         label_push(reg_counter);
@@ -804,7 +804,7 @@ case 42:
         }
 break;
 case 43:
-#line 248 "parser.y"
+#line 251 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
@@ -818,7 +818,7 @@ case 43:
         }
 break;
 case 44:
-#line 259 "parser.y"
+#line 262 "parser.y"
 	{
         set_cmp_type(SLE);
         insert_code(Icmp);
@@ -827,7 +827,7 @@ case 44:
         }
 break;
 case 45:
-#line 265 "parser.y"
+#line 268 "parser.y"
 	{
         insert_code(BrUncond);
         tmp2 = reg_counter;
@@ -849,7 +849,7 @@ case 45:
         }
 break;
 case 46:
-#line 287 "parser.y"
+#line 290 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[0].ident);
         factor_push(x);
@@ -857,7 +857,7 @@ case 46:
         }
 break;
 case 47:
-#line 292 "parser.y"
+#line 295 "parser.y"
 	{
         Factor x = create_factor_by_name(yystack.l_mark[-2].ident);
         factor_push(x);
@@ -865,7 +865,7 @@ case 47:
         }
 break;
 case 51:
-#line 308 "parser.y"
+#line 311 "parser.y"
 	{
         set_read_flag(TRUE);
         Factor x = create_factor_by_name(yystack.l_mark[-1].ident);
@@ -874,61 +874,61 @@ case 51:
         }
 break;
 case 52:
-#line 317 "parser.y"
+#line 320 "parser.y"
 	{
         set_write_flag(TRUE);
         insert_code(Write);
         }
 break;
 case 54:
-#line 328 "parser.y"
+#line 331 "parser.y"
 	{set_cmp_type(EQUAL); insert_code(Icmp);}
 break;
 case 55:
-#line 329 "parser.y"
+#line 332 "parser.y"
 	{set_cmp_type(NE); insert_code(Icmp);}
 break;
 case 56:
-#line 330 "parser.y"
+#line 333 "parser.y"
 	{set_cmp_type(SLT); insert_code(Icmp);}
 break;
 case 57:
-#line 331 "parser.y"
+#line 334 "parser.y"
 	{set_cmp_type(SLE); insert_code(Icmp);}
 break;
 case 58:
-#line 332 "parser.y"
+#line 335 "parser.y"
 	{set_cmp_type(SGT); insert_code(Icmp);}
 break;
 case 59:
-#line 333 "parser.y"
+#line 336 "parser.y"
 	{set_cmp_type(SGE); insert_code(Icmp);}
 break;
 case 63:
-#line 340 "parser.y"
+#line 343 "parser.y"
 	{insert_code(Add);}
 break;
 case 64:
-#line 341 "parser.y"
+#line 344 "parser.y"
 	{insert_code(Sub);}
 break;
 case 66:
-#line 346 "parser.y"
+#line 349 "parser.y"
 	{insert_code(Mult);}
 break;
 case 67:
-#line 347 "parser.y"
+#line 350 "parser.y"
 	{insert_code(Div);}
 break;
 case 69:
-#line 352 "parser.y"
+#line 355 "parser.y"
 	{
         Factor x = {CONSTANT, "", yystack.l_mark[0].num};
         factor_push(x);
         }
 break;
 case 71:
-#line 360 "parser.y"
+#line 363 "parser.y"
 	{
         /*ここの記号表に各処理をいじらないとだめそう*/
         /*記号表のvalの値を書き換えていく*/
@@ -938,7 +938,7 @@ case 71:
         }
 break;
 case 72:
-#line 370 "parser.y"
+#line 373 "parser.y"
 	{
         Factor x = factor_pop();
         arity_push(x);
@@ -946,7 +946,7 @@ case 72:
         }
 break;
 case 73:
-#line 375 "parser.y"
+#line 378 "parser.y"
 	{
         Factor x = factor_pop();
         arity_push(x);
@@ -954,7 +954,7 @@ case 73:
         }
 break;
 case 74:
-#line 383 "parser.y"
+#line 386 "parser.y"
 	{
         if (var_mode) {
                 insert_symbol(scope, yystack.l_mark[0].ident, count++);
@@ -964,7 +964,7 @@ case 74:
         }
 break;
 case 75:
-#line 390 "parser.y"
+#line 393 "parser.y"
 	{
         if (var_mode) {
                 insert_symbol(scope, yystack.l_mark[0].ident, count++);


### PR DESCRIPTION
# 超疲れた侍

いままでの構造だとCが吐くLLVMの形式に合致しなかったため、合うように頑張った。
## 具体的に

clangが吐くLLVMは、関数の先頭に、仮引数アドレス、返り値アドレス、局所変数アドレスの順で並ぶ。
また、仮引数アドレスを直接使うことはなく、仮引数の数だけAllocaしてそのアドレスにStoreすることで値を用いる。  
このとき、仮引数の数を`arity_num`とすると、仮引数がStoreされるアドレスは`arity_num * 2`から始まる。これは、仮引数の数を仮に1とした場合、仮引数が用いるアドレスとして`%0`が使用され、次に返り値用のアドレス`%1`が確保される。さらに仮引数の値をStoreする先のアドレス`%2`がAllocaされる。

## もっと複雑な例だと

手続き内の局所変数の数を`var_num`とおく。  
この時、手続き内のコードは、`%{arity_num}`をAllocaするコードから始まり、`%{(var_num + arity_num) + arity_num}`をAllocaするまでAllocaが続く。その後、`arity_num`回分だけ仮引数をStoreする。


現状で複数の手続き呼び出しに対して適切な処理が可能。
関数呼び出しに関しては新しい構文規則を導入する必要があると思われる。

